### PR TITLE
fix: Make the Details Page responsive

### DIFF
--- a/frontend/src/pages/details-page.tsx
+++ b/frontend/src/pages/details-page.tsx
@@ -20,7 +20,7 @@ const DetailsPage = () => {
         <div className="top-16 pl-10 md:top-24 md:pl-32 w-full justify-start lg:px-64 text-lg md:text-xl lg:text-2xl text-white absolute cursor-pointer">
           <FiArrowLeft onClick={() => navigate(-1)} />
         </div>
-        <div className="md:px-32 lg:px-64 px-8 w-full absolute bottom-16 md:bottom-40 p-4 lg:bottom-16  text-white">
+        <div className=" md:px-32 lg:px-64 px-8 w-full absolute bottom-10 md:bottom-24 p-4 lg:bottom-16  text-white">
           <div className="flex space-x-2 mb-6">
             {post.categories.map((category, index) => (
               <div key={index} className="bg-gray-500 text-white rounded-full px-3 py-1 text-sm">

--- a/frontend/src/pages/details-page.tsx
+++ b/frontend/src/pages/details-page.tsx
@@ -8,15 +8,19 @@ const DetailsPage = () => {
   const post: Post = state?.post;
   const navigate = useNavigate();
   return (
-    <div className="font-[Poppins]">
-      <div className="relative">
-        <img src={post.imageLink} alt={post.title} className="h-[460px] object-cover w-full " />
+    <div className="w-full font-[Poppins] ">
+      <div className="relative flex flex-col">
+        <img
+          src={post.imageLink}
+          alt={post.title}
+          className="h-[360px] md:h-[460px] object-cover w-full"
+        />
 
         <div className="absolute top-0 left-0 w-full h-full bg-black opacity-50"></div>
-        <div className="px-64 text-white absolute top-16 left-0 cursor-pointer">
-          <FiArrowLeft style={{ fontSize: '36px' }} onClick={() => navigate(-1)} />
+        <div className="top-16 pl-10 md:top-24 md:pl-32 w-full justify-start lg:px-64 text-lg md:text-xl lg:text-2xl text-white absolute cursor-pointer">
+          <FiArrowLeft onClick={() => navigate(-1)} />
         </div>
-        <div className="px-64 absolute bottom-16  text-white">
+        <div className="md:px-32 lg:px-64 px-8 w-full absolute bottom-16 md:bottom-40 p-4 lg:bottom-16  text-white">
           <div className="flex space-x-2 mb-6">
             {post.categories.map((category, index) => (
               <div key={index} className="bg-gray-500 text-white rounded-full px-3 py-1 text-sm">
@@ -24,12 +28,12 @@ const DetailsPage = () => {
               </div>
             ))}
           </div>
-          <h1 className="text-4xl font-semibold ">{post.title}</h1>
+          <h1 className="text-lg md:text-2xl lg:text-4xl font-semibold ">{post.title}</h1>
         </div>
       </div>
-      <div className="px-64">
+      <div className="md:pl-32 lg:px-64  text-left w-full p-6">
         <div className="mt-4">
-          <p className=" text-gray-700">{post.description}</p>
+          <p className=" text-gray-700 ">{post.description}</p>
         </div>
         <div className="mt-4 ">
           <p className=" font-semibold text-gray-600">By {post.authorName}</p>

--- a/frontend/src/pages/details-page.tsx
+++ b/frontend/src/pages/details-page.tsx
@@ -20,7 +20,7 @@ const DetailsPage = () => {
         <div className="top-16 pl-10 md:top-24 md:pl-32 w-full justify-start lg:px-64 text-lg md:text-xl lg:text-2xl text-white absolute cursor-pointer">
           <FiArrowLeft onClick={() => navigate(-1)} />
         </div>
-        <div className=" md:px-32 lg:px-64 px-8 w-full absolute bottom-10 md:bottom-24 p-4 lg:bottom-16  text-white">
+        <div className=" md:px-32 lg:px-64 px-8 w-full absolute bottom-4 md:bottom-8 p-4 lg:bottom-16  text-white">
           <div className="flex space-x-2 mb-6">
             {post.categories.map((category, index) => (
               <div key={index} className="bg-gray-500 text-white rounded-full px-3 py-1 text-sm">

--- a/frontend/src/pages/details-page.tsx
+++ b/frontend/src/pages/details-page.tsx
@@ -17,10 +17,10 @@ const DetailsPage = () => {
         />
 
         <div className="absolute top-0 left-0 w-full h-full bg-black opacity-50"></div>
-        <div className="top-16 pl-10 md:top-24 md:pl-32 w-full justify-start lg:px-64 text-lg md:text-xl lg:text-2xl text-white absolute cursor-pointer">
+        <div className="top-16 px-4 md:px-8 lg:px-16 md:top-24 w-full justify-start  text-lg md:text-xl lg:text-2xl text-white absolute cursor-pointer">
           <FiArrowLeft onClick={() => navigate(-1)} />
         </div>
-        <div className=" md:px-32 lg:px-64 px-8 w-full absolute bottom-4 md:bottom-8 p-4 lg:bottom-16  text-white">
+        <div className=" px-4 md:px-8 lg:px-16 w-full absolute bottom-4 md:bottom-8  lg:bottom-16  text-white">
           <div className="flex space-x-2 mb-6">
             {post.categories.map((category, index) => (
               <div key={index} className="bg-gray-500 text-white rounded-full px-3 py-1 text-sm">
@@ -31,7 +31,7 @@ const DetailsPage = () => {
           <h1 className="text-lg md:text-2xl lg:text-4xl font-semibold ">{post.title}</h1>
         </div>
       </div>
-      <div className="md:pl-32 lg:px-64  text-left w-full p-6">
+      <div className="px-4 md:px-8 lg:px-16 pt-4 md:pt-8 lg:pt-16  text-left w-full">
         <div className="mt-4">
           <p className=" text-gray-700 ">{post.description}</p>
         </div>

--- a/frontend/src/pages/details-page.tsx
+++ b/frontend/src/pages/details-page.tsx
@@ -31,11 +31,11 @@ const DetailsPage = () => {
           <h1 className="text-lg md:text-2xl lg:text-4xl font-semibold ">{post.title}</h1>
         </div>
       </div>
-      <div className="px-4 md:px-8 lg:px-16 pt-4 md:pt-8 lg:pt-16  text-left w-full">
-        <div className="mt-4">
+      <div className="px-4 md:px-8 lg:px-16 pt-4 md:pt-8 lg:pt-16  text-left w-full flex flex-col gap-y-4">
+        <div>
           <p className=" text-gray-700 ">{post.description}</p>
         </div>
-        <div className="mt-4 ">
+        <div className="">
           <p className=" font-semibold text-gray-600">By {post.authorName}</p>
           <p className="text-sm">{formatPostTime(post.timeOfPost)}</p>
         </div>


### PR DESCRIPTION
## Summary
Adding Responsive Layout to details page

## Description
Adjusting Margin in detail-page. Now, adding responsiveness to details page according to Laptop, Tablet, Mobile.

## Images
Mobile:

![Mo](https://github.com/krishnaacharyaa/wanderlust/assets/110713125/d3035a10-9476-4f4d-bdab-e05107742300)


Tablet:
![Ta](https://github.com/krishnaacharyaa/wanderlust/assets/110713125/3fd359db-cfca-480f-b7f9-87f2351d5b46)


Laptop:
![La](https://github.com/krishnaacharyaa/wanderlust/assets/110713125/124447fa-31fc-40b1-93f6-ad49247739e8)



## Issue(s) Addressed
- Closed #14 

## Review Checklist
Please make sure to go through this checklist before submitting your review.

- [X] Make sure the PR title is of format **`tag: Issue Title`**
   - tag should be one of `fix`,`feat`, `docs`, `chore`, `refactor`
   - Ex: `feat: Added responsive design for the home page`
- [X] Ensure the code follows our coding standards and guidelines
   - Ex:  naming conventions should be of form `file-name.ts` not `fileName.ts`
- [X] Ensure that you have staged only the required commits and raised the PR and not included all the files which would be otherwise required for local setup
- [X] Check if the PR is rebased to the latest main/development branch.
- [X] Make sure there are no unnecessary files or debugging artifacts in the PR.


