### PR TITLE
refactor: Rename few API endpoints to follow industry standards

### DIFF
--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -24,7 +24,7 @@ router.get('/', async (req, res) => {
 });
 
 // Route to get featured posts
-router.get('/featured-posts', async (req, res) => {
+router.get('/featured', async (req, res) => {
   try {
     const featuredPosts = await Post.find({ isFeaturedPost: true });
     res.json(featuredPosts);
@@ -34,7 +34,7 @@ router.get('/featured-posts', async (req, res) => {
 });
 
 // Route to get posts by category
-router.get('/category/:category', async (req, res) => {
+router.get('/categories/:category', async (req, res) => {
   const category = req.params.category;
   try {
     const categoryPosts = await Post.find({ categories: category });
@@ -45,7 +45,7 @@ router.get('/category/:category', async (req, res) => {
 });
 
 // Route for fetching the latest posts
-router.get('/latestposts', async (req, res) => {
+router.get('/latest', async (req, res) => {
   try {
     const latestPosts = await Post.find().sort({ timeOfPost: -1 });
     res.json(latestPosts);

--- a/frontend/src/components/blog-feed.tsx
+++ b/frontend/src/components/blog-feed.tsx
@@ -12,8 +12,8 @@ export default function BlogFeed() {
   useEffect(() => {
     let categoryEndpoint =
       selectedCategory === 'featured'
-        ? '/api/posts/featured-posts'
-        : `/api/posts/category/${selectedCategory}`;
+        ? '/api/posts/featured'
+        : `/api/posts/categories/${selectedCategory}`;
 
     axios
       .get(import.meta.env.VITE_API_PATH + categoryEndpoint)
@@ -27,7 +27,7 @@ export default function BlogFeed() {
 
   useEffect(() => {
     axios
-      .get(import.meta.env.VITE_API_PATH + '/api/posts/latestposts')
+      .get(import.meta.env.VITE_API_PATH + '/api/posts/latest')
       .then((response) => {
         setLatestPosts(response.data);
       })


### PR DESCRIPTION
## Summary
Rename a few API endpoint names to follow industry standards

## Description
There are some REST API naming conventions that the industry is used to and it's a good practice to follow best practices.

Check these out -
1. [REST API URI Naming Conventions and Best Practices](https://restfulapi.net/resource-naming/)
2. [Best practices for REST API design](https://stackoverflow.blog/2020/03/02/best-practices-for-rest-api-design)
3. [RESTful web API design](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)

In this change, I have -
1. Renamed `latestposts` and `featured-posts` sans `post` since we're already in the `/posts` resource category.
5. According to the conventions, use plural nouns unless it's a singleton resource. Here, for example, `categories/adventure` endpoint is designed to respond with multiple posts, so it make sense to rename `category` to a plural noun.

## Images
No relavant images.


## Issue(s) Addressed
Haven't open an issue for this change.

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions) ?
