### PR TITLE
docs: Change the styling of setup instructions for better readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ WanderLust is a simple MERN travel blog website ✈ This project is aimed to hel
 ## [Figma Design File](https://www.figma.com/file/zqNcWGGKBo5Q2TwwVgR6G5/WanderLust--A-Travel-Blog-App?type=design&node-id=0%3A1&mode=design&t=c4oCG8N1Fjf7pxTt-1)
 
 ## 🎯 Goal of this project
+
 At its core, this project embodies two important aims:
 
 1. **Start Your Open Source Journey**: It's aimed to kickstart your open-source journey. Here, you'll learn the basics of Git and get a solid grip on the MERN stack and I strongly believe that learning and building should go hand in hand.
@@ -15,24 +16,77 @@ At its core, this project embodies two important aims:
 _I'd love for you to make the most of this project - it's all about learning, helping, and growing in the open-source world._
 
 ## Setting up the project locally
+
 ### Setting up the Backend
-1. Fork and clone the repository
-2. Navigate to the `backend` directory, run `cd backend`
-3. Run `npm ci` to install the required dependencies.
-4. Set up your MongoDB database:
-   - Open MongoDB Compass and run MongoDB locally at `mongodb://localhost:27017`.
-5. Rename the `.env.sample` file to `.env`.
-6. Start the backend server with `npm start`
-7. Import sample posts by copying the content from
-    - `backend/data/sample_posts.json` and insert it as a document in the
-    - `wanderlust/posts` collection in your local MongoDB database.
+
+1. **Fork and Clone the Repository**
+
+```bash
+git clone https://github.com/{your-username}/wanderlust.git
+```
+
+2. **Navigate to the Backend Directory**
+
+```bash
+cd backend
+```
+
+3. **Install Required Dependencies**
+
+```bash
+npm ci
+```
+
+4. **Set up your MongoDB Database**
+
+   - Open MongoDB Compass and connect MongoDB locally at `mongodb://localhost:27017`.
+
+5. **Import sample data**
+To populate the database with sample posts, you can copy the content from the `backend/data/sample_posts.json` file and insert it as a document in the `wanderlust/posts` collection in your local MongoDB database using either MongoDB Compass or `mongoimport`.
+
+```bash
+mongoimport --db wanderlust --collection posts --file ./data/sample_posts.json --jsonArray
+```
+
+6. **Configure Environment Variables**
+
+```bash
+cp .env.sample .env
+```
+
+7. **Start the Backend Server**
+
+```bash
+npm start
+```
+
+You should see `Server is running on port 5000` on your terminal output.
 
 ### Setting up the Frontend
-1. Open a new terminal
-2. Navigate to the `frontend` directory, run `cd frontend`
-3. Run `npm ci` to install the necessary frontend dependencies.
-4. Rename the `.env.sample` file to `.env.local`.
-5. Launch the development server with `npm run dev`.
+
+1. **Open a New Terminal**
+
+```bash
+cd frontend
+```
+
+2. **Install Dependencies**
+
+```bash
+npm ci
+```
+
+3. **Configure Environment Variables**
+
+```bash
+cp .env.sample .env.local
+```
+
+4. **Launch the Development Server**
+
+```bash
+npm run dev
+```
 
 ## 🌟 Ready to Contribute?
 


### PR DESCRIPTION


## Summary
Change the styling of setup instructions for better readability

## Description
 - Use block code for commands instead of inline code. It's easier to read, copy, and paste the commands. GitHub also has the copy button for block commands.

Copy button:
![image](https://github.com/krishnaacharyaa/wanderlust/assets/6230769/11e82d7b-7083-4c79-9418-cebca8e62114)


- Add instructions to import sample data from `sample_posts.json` file using `mongoimport` command.

- **Copy** (`cp .env.sample .env`) instead of **Rename** (`mv .env.sample .env`) because git will track it as a change and you will see .env.sample file as a deleted git object. On the other hand, since we have already ignored .env* files, git won't track it and we keep the sample file untouched.

No tracked changes here:
![image](https://github.com/krishnaacharyaa/wanderlust/assets/6230769/036c1722-1f4f-4bdc-a1e2-1827efbce7d8)

