### PR TITLE
refactor-66: Disable other option when three categories is selected

### DIFF
--- a/frontend/src/pages/add-blog.tsx
+++ b/frontend/src/pages/add-blog.tsx
@@ -40,17 +40,15 @@ function AddBlog() {
   };
 
   const handleCategoryClick = (category: string) => {
-    if (formData.categories.includes(category)) {
+    if (formData.categories.length <= 2 || formData.categories.includes(category)) {
       setFormData({
         ...formData,
-        categories: formData.categories.filter((cat) => cat !== category),
+        categories: formData.categories.includes(category) ? formData.categories.filter((cat) => cat !== category) : [...formData.categories, category],
       });
-    } else {
-      setFormData({
-        ...formData,
-        categories: [...formData.categories, category],
-      });
+      return;
     }
+    toast.error('Select up to three categories.');
+    return;
   };
   const handleselector = () => {
     setFormData({
@@ -199,10 +197,9 @@ function AddBlog() {
               <span
                 key={category}
                 className={`cursor-pointer
-									${
-                    formData.categories.includes(category)
-                      ? categoryProps(category, true)
-                      : categoryProps(category, false)
+									${formData.categories.includes(category)
+                    ? categoryProps(category, true)
+                    : categoryProps(category, false)
                   }`}
                 onClick={() => handleCategoryClick(category)}
               >

--- a/frontend/src/pages/add-blog.tsx
+++ b/frontend/src/pages/add-blog.tsx
@@ -119,6 +119,7 @@ function AddBlog() {
       mediaQuery.removeListener(handleThemeChange);
     };
   }, []);
+  const isDisable = formData.categories.length === 3;
 
   return (
     <div className="min-h-screen bg-white p-4 px-16 font-[Poppins] dark:bg-dark">
@@ -196,10 +197,10 @@ function AddBlog() {
             {CATEGORIES.map((category) => (
               <span
                 key={category}
-                className={`cursor-pointer
+                className={`${isDisable && !formData.categories.includes(category) ? "cursor-default" : "cursor-pointer"}
 									${formData.categories.includes(category)
-                    ? categoryProps(category, true)
-                    : categoryProps(category, false)
+                    ? categoryProps(category, true, isDisable ? true : false)
+                    : categoryProps(category, false, isDisable ? true : false)
                   }`}
                 onClick={() => handleCategoryClick(category)}
               >

--- a/frontend/src/pages/add-blog.tsx
+++ b/frontend/src/pages/add-blog.tsx
@@ -47,8 +47,6 @@ function AddBlog() {
       });
       return;
     }
-    toast.error('Select up to three categories.');
-    return;
   };
   const handleselector = () => {
     setFormData({
@@ -197,7 +195,7 @@ function AddBlog() {
             {CATEGORIES.map((category) => (
               <span
                 key={category}
-                className={`${isDisable && !formData.categories.includes(category) ? "cursor-default" : "cursor-pointer"}
+                className={`${isDisable && !formData.categories.includes(category) ? "cursor-not-allowed" : "cursor-pointer"}
 									${formData.categories.includes(category)
                     ? categoryProps(category, true, isDisable ? true : false)
                     : categoryProps(category, false, isDisable ? true : false)

--- a/frontend/src/utils/category-props.tsx
+++ b/frontend/src/utils/category-props.tsx
@@ -1,25 +1,25 @@
 let commonProps: string = 'px-3 py-1 rounded-3xl font-normal text-sm';
-export const categoryProps = (category: string, selected: boolean = false) => {
+export const categoryProps = (category: string, selected: boolean = false, disable: boolean = false) => {
   switch (category) {
     case 'Travel':
-      return `${commonProps} ${selected ? `bg-pink-500` : `bg-pink-100`}`;
+      return `${commonProps} ${selected ? `bg-pink-500` : disable ? `bg-slate-100 text-slate-400` : `bg-pink-100`}`;
 
     case 'Nature':
-      return `${commonProps} ${selected ? `bg-green-500` : `bg-green-100`}`;
+      return `${commonProps} ${selected ? `bg-green-500` : disable ? `bg-slate-100 text-slate-400` : `bg-green-100`}`;
 
     case 'City':
-      return `${commonProps} ${selected ? `bg-yellow-500` : `bg-yellow-100`}`;
+      return `${commonProps} ${selected ? `bg-yellow-500` : disable ? `bg-slate-100 text-slate-400` : `bg-yellow-100`}`;
 
     case 'Adventure':
-      return `${commonProps} ${selected ? `bg-blue-500` : `bg-blue-100`}`;
+      return `${commonProps} ${selected ? `bg-blue-500` : disable ? `bg-slate-100 text-slate-400` : `bg-blue-100`}`;
 
     case 'Beaches':
-      return `${commonProps} ${selected ? `bg-purple-500` : `bg-purple-100`}`;
+      return `${commonProps} ${selected ? `bg-purple-500` : disable ? `bg-slate-100 text-slate-400` : `bg-purple-100`}`;
 
     case 'Landmarks':
-      return `${commonProps} ${selected ? `bg-red-500` : `bg-red-100`}`;
+      return `${commonProps} ${selected ? `bg-red-500` : disable ? `bg-slate-100 text-slate-400` : `bg-red-100`}`;
 
     default:
-      return `${commonProps} ${selected ? `bg-orange-500` : `bg-orange-100`}`;
+      return `${commonProps} ${selected ? `bg-orange-500` : disable ? `bg-slate-100 text-slate-400` : `bg-orange-100`}`;
   }
 };


### PR DESCRIPTION
## Summary

Disable other option when three categories is selected

## Description

To improve the current UX, disable the remaining categories when the user selects three categories while a new blog post is being created.

## Current Behavior

Currently if a user selects more than three categories, they won't get any feedback until after clicking on the "Create Blog" button.This degrades the UX as they will have to unselect certain categories and try to click on the submit button again.

##Fixed Behavior

I propose that once the user selects three categories, other categories go into a disabled state.
If the user de-selects one of the three, all the categories will be shown as available again.

## Issue(s) Addressed

 Closes #66 

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
