### PR TITLE
refactor: Disable other options if three categories are selected while creating a post

### DIFF
--- a/frontend/src/components/category-pill.tsx
+++ b/frontend/src/components/category-pill.tsx
@@ -4,16 +4,20 @@ import { twMerge } from 'tailwind-merge';
 interface CategoryPillProps extends React.HTMLAttributes<HTMLSpanElement> {
   category: string;
   selected?: boolean;
+  disabled?: boolean;
 }
 
-export default function CategoryPill({ category, selected = false }: CategoryPillProps) {
+
+export default function CategoryPill({ category, selected = false, disabled = false }: CategoryPillProps) {
   const [defaultColor, selectedColor]: [string, string] = getCategoryColors(category);
+  const disabledColor: string = "bg-slate-100 text-slate-400 cursor-not-allowed"
 
   return (
     <span
       className={twMerge(
         'cursor-pointer rounded-3xl px-3 py-1 text-xs font-medium text-light-primary/80 dark:text-dark-primary/80',
-        selected ? selectedColor : defaultColor
+        selected ? selectedColor : defaultColor,
+        disabled && disabledColor
       )}
     >
       {category}

--- a/frontend/src/pages/add-blog.tsx
+++ b/frontend/src/pages/add-blog.tsx
@@ -40,15 +40,10 @@ function AddBlog() {
   };
 
   const handleCategoryClick = (category: string) => {
-    if (formData.categories.includes(category)) {
+    if (formData.categories.length <= 2 || formData.categories.includes(category)) {
       setFormData({
         ...formData,
-        categories: formData.categories.filter((cat) => cat !== category),
-      });
-    } else {
-      setFormData({
-        ...formData,
-        categories: [...formData.categories, category],
+        categories: formData.categories.includes(category) ? formData.categories.filter((cat) => cat !== category) : [...formData.categories, category]
       });
     }
   };
@@ -125,6 +120,8 @@ function AddBlog() {
   function Asterisk() {
     return <span className="dark:text-dark-tertiary">*</span>;
   }
+
+  const isValidCategory = (category: string) => !formData.categories.includes(category) && formData.categories.length === 3
 
   return (
     <div className="min-h-screen cursor-default bg-slate-50 px-6 py-8 dark:bg-dark">
@@ -238,6 +235,7 @@ function AddBlog() {
               {categories.map((category, index) => (
                 <span key={`${category}-${index}`} onClick={() => handleCategoryClick(category)}>
                   <CategoryPill
+                    disabled={isValidCategory(category)}
                     category={category}
                     selected={formData.categories.includes(category)}
                   />


### PR DESCRIPTION
## Summary

Disable other options if three categories are selected while creating a post

## Description

To improve the current UX, disable the remaining categories when the user selects three categories while a new blog post is being created.

## Images

![Screenshot from 2023-12-06 10-35-30](https://github.com/krishnaacharyaa/wanderlust/assets/93524571/7e8ecb87-d6cd-4f7b-9314-d7b9060de564)

## Issue(s) Addressed

 Closes #66 

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
