### PR TITLE
fix-#106 : Loading screen(Skeleton) now comes up when posts are filte…

### DIFF
--- a/frontend/src/components/blog-feed.tsx
+++ b/frontend/src/components/blog-feed.tsx
@@ -11,6 +11,7 @@ export default function BlogFeed() {
   const [selectedCategory, setSelectedCategory] = useState('featured');
   const [posts, setPosts] = useState([]);
   const [latestPosts, setLatestPosts] = useState([]);
+  const [loading,setLoading]=useState(true)
 
   useEffect(() => {
     let categoryEndpoint =
@@ -18,10 +19,12 @@ export default function BlogFeed() {
         ? '/api/posts/featured'
         : `/api/posts/categories/${selectedCategory}`;
 
+      setLoading(true)
     axios
       .get(import.meta.env.VITE_API_PATH + categoryEndpoint)
       .then((response) => {
-        setPosts(response.data);
+          setPosts(response.data);
+          setLoading(false)
       })
       .catch((error) => {
         console.error(error);
@@ -52,7 +55,7 @@ export default function BlogFeed() {
               : `Posts related to "${selectedCategory}"`}
           </h1>
           <div className="flex flex-col gap-6">
-            {posts.length === 0
+            {posts.length === 0 || loading==true
               ? Array(5)
                   .fill(0)
                   .map((_, index) => <FeaturedPostCardSkeleton key={index} />)

--- a/frontend/src/components/blog-feed.tsx
+++ b/frontend/src/components/blog-feed.tsx
@@ -11,7 +11,7 @@ export default function BlogFeed() {
   const [selectedCategory, setSelectedCategory] = useState('featured');
   const [posts, setPosts] = useState([]);
   const [latestPosts, setLatestPosts] = useState([]);
-  const [loading,setLoading]=useState(true)
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     let categoryEndpoint =
@@ -19,12 +19,12 @@ export default function BlogFeed() {
         ? '/api/posts/featured'
         : `/api/posts/categories/${selectedCategory}`;
 
-      setLoading(true)
+    setLoading(true);
     axios
       .get(import.meta.env.VITE_API_PATH + categoryEndpoint)
       .then((response) => {
-          setPosts(response.data);
-          setLoading(false)
+        setPosts(response.data);
+        setLoading(false);
       })
       .catch((error) => {
         console.error(error);
@@ -55,7 +55,7 @@ export default function BlogFeed() {
               : `Posts related to "${selectedCategory}"`}
           </h1>
           <div className="flex flex-col gap-6">
-            {posts.length === 0 || loading==true
+            {posts.length === 0 || loading == true
               ? Array(5)
                   .fill(0)
                   .map((_, index) => <FeaturedPostCardSkeleton key={index} />)

--- a/frontend/src/components/featured-post-card.tsx
+++ b/frontend/src/components/featured-post-card.tsx
@@ -13,7 +13,7 @@ export default function FeaturedPostCard({
   const slug = createSlug(post.title);
   return (
     <div
-      className="flex flex-col sm:flex-row h-auto sm:h-48 cursor-pointer gap-2 rounded-lg bg-light dark:bg-dark-card"
+      className="flex h-auto cursor-pointer flex-col gap-2 rounded-lg bg-light dark:bg-dark-card sm:h-48 sm:flex-row"
       onClick={() => navigate(`/details-page/${slug}/${post._id}`, { state: { post } })}
       data-testid={testId}
     >
@@ -21,11 +21,11 @@ export default function FeaturedPostCard({
         <img
           src={post.imageLink}
           alt={post.title}
-          className="h-48 sm:h-full w-full rounded-lg object-cover shadow-lg"
+          className="h-48 w-full rounded-lg object-cover shadow-lg sm:h-full"
         />
       </div>
-      <div className="flex flex-col h-full w-full sm:w-2/3 gap-2 p-3">
-        <div className="text-base line-clamp-1 font-semibold text-light-title dark:text-dark-title">
+      <div className="flex h-full w-full flex-col gap-2 p-3 sm:w-2/3">
+        <div className="line-clamp-1 text-base font-semibold text-light-title dark:text-dark-title">
           {post.title}
         </div>
         <div className="flex flex-wrap gap-2">

--- a/frontend/src/components/post-card.tsx
+++ b/frontend/src/components/post-card.tsx
@@ -11,9 +11,7 @@ export default function PostCard({ post, testId = 'postcard' }: { post: Post } &
   return (
     <div className="w-full md:w-1/2 lg:w-1/3 xl:w-1/4" data-testid={testId}>
       <div
-        className={`cursor-pointer rounded-lg bg-light shadow-md dark:bg-dark-card mb-4 ${
-          'md:mr-8 md:mt-4'
-        }`}
+        className={`mb-4 cursor-pointer rounded-lg bg-light shadow-md dark:bg-dark-card ${'md:mr-8 md:mt-4'}`}
         onClick={() => navigate(`/details-page/${slug}/${post._id}`, { state: { post } })}
       >
         <img

--- a/frontend/src/components/skeletons/featured-post-card-skeleton.tsx
+++ b/frontend/src/components/skeletons/featured-post-card-skeleton.tsx
@@ -8,13 +8,13 @@ export const FeaturedPostCardSkeleton = () => {
     >
       {/* for image */}
       <div className="w-full sm:w-1/3">
-        <Skeleton className="h-48 sm:h-full w-full rounded-lg bg-slate-200 dark:bg-slate-700" />
+        <Skeleton className="h-48 w-full rounded-lg bg-slate-200 dark:bg-slate-700 sm:h-full" />
       </div>
-      <div className="flex flex-col sm:w-2/3 gap-4 rounded-lg p-3">
+      <div className="flex flex-col gap-4 rounded-lg p-3 sm:w-2/3">
         <div className="flex w-full flex-col gap-3">
           {/* for title */}
-          <Skeleton className="h-6 w-full sm:w-11/12 bg-slate-200 dark:bg-slate-700" />
-          <Skeleton className="h-6 w-full sm:w-2/3 bg-slate-200 dark:bg-slate-700" />
+          <Skeleton className="h-6 w-full bg-slate-200 dark:bg-slate-700 sm:w-11/12" />
+          <Skeleton className="h-6 w-full bg-slate-200 dark:bg-slate-700 sm:w-2/3" />
           <div className="flex flex-wrap gap-2">
             {/* for categories */}
             {Array(3)
@@ -22,15 +22,15 @@ export const FeaturedPostCardSkeleton = () => {
               .map((_, index) => (
                 <Skeleton
                   key={index}
-                  className="h-6 w-full sm:w-16 rounded-full bg-slate-200 dark:bg-slate-700"
+                  className="h-6 w-full rounded-full bg-slate-200 dark:bg-slate-700 sm:w-16"
                 />
               ))}
           </div>
           {/* for description */}
-          <Skeleton className="line-clamp-2 h-12 w-full sm:w-10/12 bg-slate-200 dark:bg-slate-700" />
+          <Skeleton className="line-clamp-2 h-12 w-full bg-slate-200 dark:bg-slate-700 sm:w-10/12" />
           <div className="mb-1 flex flex-1 items-end">
             {/* for author and time */}
-            <Skeleton className="h-3 w-full sm:w-1/3 bg-slate-200 dark:bg-slate-700" />
+            <Skeleton className="h-3 w-full bg-slate-200 dark:bg-slate-700 sm:w-1/3" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/skeletons/post-card-skeleton.tsx
+++ b/frontend/src/components/skeletons/post-card-skeleton.tsx
@@ -6,19 +6,15 @@ export const PostCardSkeleton = () => {
       <div className="mb-4 mr-8 mt-4 rounded-lg bg-light shadow-md dark:bg-dark-card">
         <Skeleton className="h-48 w-full rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="p-4">
-          <Skeleton className="mb-2 h-3 w-full sm:w-2/3 bg-slate-200 dark:bg-slate-700" />
-          <Skeleton className="mb-2 h-6 w-full sm:w-4/5 bg-slate-200 dark:bg-slate-700" />
-          <Skeleton className="h-16 w-full sm:w-11/12 bg-slate-200 dark:bg-slate-700" />
+          <Skeleton className="mb-2 h-3 w-full bg-slate-200 dark:bg-slate-700 sm:w-2/3" />
+          <Skeleton className="mb-2 h-6 w-full bg-slate-200 dark:bg-slate-700 sm:w-4/5" />
+          <Skeleton className="h-16 w-full bg-slate-200 dark:bg-slate-700 sm:w-11/12" />
           <div className="mt-2 flex flex-wrap gap-2">
             <Skeleton
-              className={`h-6 w-full sm:w-16 rounded-full ${
-                'sm:mr-8 sm:mt-4'
-              } sm:mb-4 bg-slate-200 dark:bg-slate-700`}
+              className={`h-6 w-full rounded-full sm:w-16 ${'sm:mr-8 sm:mt-4'} bg-slate-200 dark:bg-slate-700 sm:mb-4`}
             />
             <Skeleton
-              className={`h-6 w-full sm:w-16 rounded-full ${
-                'sm:mr-8 sm:mt-4'
-              } sm:mb-4 bg-slate-200 dark:bg-slate-700`}
+              className={`h-6 w-full rounded-full sm:w-16 ${'sm:mr-8 sm:mt-4'} bg-slate-200 dark:bg-slate-700 sm:mb-4`}
             />
           </div>
         </div>

--- a/frontend/src/pages/home-page.tsx
+++ b/frontend/src/pages/home-page.tsx
@@ -64,13 +64,13 @@ function HomePage() {
               Dive into the world of travel with stories that transport you to far-off lands.
               Adventure awaits around every corner. It's time to explore the world!
             </p>
-            <div className="text-sm md:text-xl font-semibold">Let's go!</div>
+            <div className="text-sm font-semibold md:text-xl">Let's go!</div>
           </div>
         </div>
       </div>
       <div className="mx-4 md:mx-8 lg:mx-16">
         <BlogFeed />
-        <h1 className="text-xl sm:pb-0 pb-4 font-semibold dark:text-dark-primary">All Posts</h1>
+        <h1 className="pb-4 text-xl font-semibold dark:text-dark-primary sm:pb-0">All Posts</h1>
         <div className="flex flex-wrap">
           {posts.length === 0
             ? Array(8)


### PR DESCRIPTION
…red based on the category till the time posts as per the category is not there

## Summary

Thie PR successfully resolved the issue #106 
So, now the Loading screen(Skeleton) now comes up when posts are filtered based on the category till the time posts as per the category is not there.

## Description

My approach was pretty much straightforward addressing the issue, I took state variables named loading, initially set it to true, everytime anykind of request was made, I set this loading variable true and once data fetching is done and stored in the Posts named state variable, I set the loading variable false and to the issue I resolved, simply wrote the logic, if the loading is true, we are gonna render the skeleton component otherwise the post card as per the category and done!

## Images
Here is the demonstration of how is it resolving the issue
[screen-capture (1).webm](https://github.com/krishnaacharyaa/wanderlust/assets/68687087/dbfaeabe-5ba1-4ac7-a473-8be45145214d)


_Include any relevant images or diagrams that can help reviewers visualize the changes, if applicable_

## Issue(s) Addressed
#106 

Closes #106
## Prerequisites

- [Yes ] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
