### PR TITLE
Bugfix/109 featured posts card is not inline with the skeleton card

### DIFF
--- a/frontend/src/components/skeletons/featured-post-card-skeleton.tsx
+++ b/frontend/src/components/skeletons/featured-post-card-skeleton.tsx
@@ -1,20 +1,26 @@
-import { Skeleton } from "../ui/skeleton";
+import { Skeleton } from '@/components/ui/skeleton';
 
 export const FeaturedPostCardSkeleton = () => {
   return (
-    <div className="flex flex-col sm:flex-row rounded-lg bg-light dark:bg-dark-card" data-testid="featurepostcardskeleton">
+    <div
+      className="flex flex-col rounded-lg bg-light dark:bg-dark-card sm:flex-row"
+      data-testid="featurepostcardskeleton"
+    >
       {/* Image */}
-      <div className="w-full sm:w-1/3 mb-4 sm:mb-0">
-        <Skeleton className="h-48 sm:h-full w-full rounded-lg bg-slate-200 dark:bg-slate-700" />
+      <div className="mb-4 w-full sm:mb-0 sm:w-1/3">
+        <Skeleton
+          className="h-50 w-full rounded-lg bg-slate-200 object-cover shadow-lg dark:bg-slate-700 sm:h-full"
+          style={{ height: '190px' }}
+        />
       </div>
 
       {/* Content */}
-      <div className="flex flex-col sm:w-2/3 p-3">
+      <div className="flex flex-col p-3 sm:w-2/3">
         {/* Title */}
-        <Skeleton className="h-6 w-full mb-2 bg-slate-200 dark:bg-slate-700" />
-        
+        <Skeleton className="mb-3 h-6 w-full bg-slate-200 dark:bg-slate-700" />
+
         {/* Categories */}
-        <div className="flex flex-wrap gap-2 mb-2">
+        <div className="mb-3 flex flex-wrap gap-2">
           {Array(3)
             .fill(0)
             .map((_, index) => (
@@ -24,10 +30,10 @@ export const FeaturedPostCardSkeleton = () => {
               />
             ))}
         </div>
-        
+
         {/* Description */}
-        <Skeleton className="h-12 w-full mb-2 bg-slate-200 dark:bg-slate-700" />
-        
+        <Skeleton className="mb-4 h-16 w-full bg-slate-200 dark:bg-slate-700" />
+
         {/* Author and Time */}
         <div className="flex items-end">
           <Skeleton className="h-3 w-1/3 bg-slate-200 dark:bg-slate-700" />

--- a/frontend/src/components/skeletons/featured-post-card-skeleton.tsx
+++ b/frontend/src/components/skeletons/featured-post-card-skeleton.tsx
@@ -1,37 +1,36 @@
-import { Skeleton } from '@/components/ui/skeleton';
+import { Skeleton } from "../ui/skeleton";
 
 export const FeaturedPostCardSkeleton = () => {
   return (
-    <div
-      className="flex rounded-lg bg-light dark:bg-dark-card"
-      data-testid="featurepostcardskeleton"
-    >
-      {/* for image */}
-      <div className="w-full sm:w-1/3">
+    <div className="flex flex-col sm:flex-row rounded-lg bg-light dark:bg-dark-card" data-testid="featurepostcardskeleton">
+      {/* Image */}
+      <div className="w-full sm:w-1/3 mb-4 sm:mb-0">
         <Skeleton className="h-48 sm:h-full w-full rounded-lg bg-slate-200 dark:bg-slate-700" />
       </div>
-      <div className="flex flex-col sm:w-2/3 gap-4 rounded-lg p-3">
-        <div className="flex w-full flex-col gap-3">
-          {/* for title */}
-          <Skeleton className="h-6 w-full sm:w-11/12 bg-slate-200 dark:bg-slate-700" />
-          <Skeleton className="h-6 w-full sm:w-2/3 bg-slate-200 dark:bg-slate-700" />
-          <div className="flex flex-wrap gap-2">
-            {/* for categories */}
-            {Array(3)
-              .fill(0)
-              .map((_, index) => (
-                <Skeleton
-                  key={index}
-                  className="h-6 w-full sm:w-16 rounded-full bg-slate-200 dark:bg-slate-700"
-                />
-              ))}
-          </div>
-          {/* for description */}
-          <Skeleton className="line-clamp-2 h-12 w-full sm:w-10/12 bg-slate-200 dark:bg-slate-700" />
-          <div className="mb-1 flex flex-1 items-end">
-            {/* for author and time */}
-            <Skeleton className="h-3 w-full sm:w-1/3 bg-slate-200 dark:bg-slate-700" />
-          </div>
+
+      {/* Content */}
+      <div className="flex flex-col sm:w-2/3 p-3">
+        {/* Title */}
+        <Skeleton className="h-6 w-full mb-2 bg-slate-200 dark:bg-slate-700" />
+        
+        {/* Categories */}
+        <div className="flex flex-wrap gap-2 mb-2">
+          {Array(3)
+            .fill(0)
+            .map((_, index) => (
+              <Skeleton
+                key={index}
+                className="h-6 w-16 rounded-full bg-slate-200 dark:bg-slate-700"
+              />
+            ))}
+        </div>
+        
+        {/* Description */}
+        <Skeleton className="h-12 w-full mb-2 bg-slate-200 dark:bg-slate-700" />
+        
+        {/* Author and Time */}
+        <div className="flex items-end">
+          <Skeleton className="h-3 w-1/3 bg-slate-200 dark:bg-slate-700" />
         </div>
       </div>
     </div>

--- a/frontend/src/components/skeletons/featured-post-card-skeleton.tsx
+++ b/frontend/src/components/skeletons/featured-post-card-skeleton.tsx
@@ -32,7 +32,7 @@ export const FeaturedPostCardSkeleton = () => {
         </div>
 
         {/* Description */}
-        <Skeleton className="mb-4 h-16 w-full bg-slate-200 dark:bg-slate-700" />
+        <Skeleton className="mb-4 h-10 sm:h-16 lg:h-16 w-full bg-slate-200 dark:bg-slate-700" />
 
         {/* Author and Time */}
         <div className="flex items-end">


### PR DESCRIPTION
## Summary
Fix all the issue of the featured posts card which is not inline with the skeleton card (shimmer card)

## Description

fix the inline issue in the featured Posts of skeleton UI across all devices

## Issue(s) Addressed

-The issue number of the bug(s) that this PR fixes_

- Closes #109 

## Prerequisites

- Yes I followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
