### PR TITLE
Bugfix/98 In Theme-Toggle-Button #98

### DIFF
--- a/frontend/src/components/theme-toggle-button.tsx
+++ b/frontend/src/components/theme-toggle-button.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import Sun from '@/assets/svg/sun.svg';
 import Moon from '@/assets/svg/moon.svg';
 function ThemeToggle() {
@@ -6,7 +6,7 @@ function ThemeToggle() {
   const toggleTheme = () => {
     setIsDarkTheme((prevTheme) => (prevTheme === null ? true : !prevTheme));
   };
-  useEffect(() => {
+  useLayoutEffect(() => {
     const storedTheme = localStorage.getItem('theme');
     const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
     setIsDarkTheme(storedTheme === 'dark' || (!storedTheme && prefersDark) || null);
@@ -15,7 +15,7 @@ function ThemeToggle() {
     }
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isDarkTheme !== null) {
       document.documentElement.classList.toggle('dark', isDarkTheme);
 


### PR DESCRIPTION
## Summary

This PR is to fix the flickering issue of the theme toggle button

## Description

This issue has occured because the callback function inside the useEffect only runs after the dom mutations and browser paints the screen.So in order to fix that I used useLayoutEffect instead of useEffect as the provided callback inside the useLayoutEffect runs before the browser paints the screen.

## Images

https://github.com/krishnaacharyaa/wanderlust/assets/140341777/5384016a-f957-4e40-ad6f-6f01bccc58ae

## Issue(s) Addressed

Closes #98 


## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?

