### PR TITLE
tag-#110: Latest Post Card Skeleton Alignment Bug Fixed

### DIFF
--- a/frontend/src/components/skeletons/latest-post-card-skeleton.tsx
+++ b/frontend/src/components/skeletons/latest-post-card-skeleton.tsx
@@ -17,9 +17,8 @@ export const LatestPostCardSkeleton = () => {
       </div>
       <div className="mb-2">
         <Skeleton className="h-6 w-11/12 bg-slate-200 dark:bg-slate-700" />
-        <Skeleton className="mt-2 h-4 w-2/3 bg-slate-200 dark:bg-slate-700" />
       </div>
-      <Skeleton className="h-3 w-1/3 bg-slate-200 dark:bg-slate-700" />
+      <Skeleton className="h-3 w-2/3 bg-slate-200 dark:bg-slate-700" />
     </div>
   );
 };

--- a/frontend/src/components/skeletons/latest-post-card-skeleton.tsx
+++ b/frontend/src/components/skeletons/latest-post-card-skeleton.tsx
@@ -18,7 +18,7 @@ export const LatestPostCardSkeleton = () => {
       <div className="mb-2">
         <Skeleton className="h-6 w-11/12 bg-slate-200 dark:bg-slate-700" />
       </div>
-      <Skeleton className="h-3 w-2/3 bg-slate-200 dark:bg-slate-700" />
+      <Skeleton className="h-3 w-3/4 bg-slate-200 dark:bg-slate-700" />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

This PR fixes the bug of the latest post card skeleton.

## Description

The third Row of the latest postcard skeleton is removed. Author and date row is little more wider now

## Images
![320351235-09b30b4c-121a-4044-b60b-2d6012a8661a](https://github.com/krishnaacharyaa/wanderlust/assets/109821078/3c7beac4-bd46-46e1-9d24-fef57651b7ef)


## Issue(s) Addressed

Closes #110 

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
