### PR TITLE
fix-#172: solve the error when Login of the user does not stay if I refresh the page.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,8 @@
     "lucide-react": "^0.292.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "@types/js-cookie": "^3.0.6",
+    "react-cookie": "^7.1.4",
     "react-hook-form": "^7.51.2",
     "react-router-dom": "^6.18.0",
     "react-tag-input": "^6.8.1",

--- a/frontend/src/layouts/header-layout.tsx
+++ b/frontend/src/layouts/header-layout.tsx
@@ -8,27 +8,30 @@ import { useEffect, useState } from 'react';
 import axios from 'axios';
 import { toast } from 'react-toastify';
 import userState from '@/utils/user-state';
+import { useCookies } from 'react-cookie';
 function header() {
   const navigate = useNavigate();
-
   const [accessToken, setAccessToken] = useState<string | null>(userState.getUser());
+  const [allCookies] = useCookies(['accessToken']);
+
+  setTimeout(() => {
+    setAccessToken(null);
+  }, 240 * 1000);
 
   useEffect(() => {
-    const storedAccessToken = userState.getUser();
-
+    const storedAccessToken = allCookies.accessToken;
     if (storedAccessToken) {
-      setAccessToken(storedAccessToken);
+      setAccessToken(allCookies.accessToken);
     }
-  }, [accessToken, userState]);
+  }, []);
 
   const handleLogout = async () => {
     try {
       const response = await axios.post(import.meta.env.VITE_API_PATH + '/api/auth/signout');
 
       if (response.status === 200) {
-        toast.success(response.data.message);
-        userState.setUser(null);
         setAccessToken(null);
+        toast.success(response.data.message);
         navigate('/');
       } else {
         toast.error('Error: ' + response.data.message);

--- a/frontend/src/pages/signin-page.tsx
+++ b/frontend/src/pages/signin-page.tsx
@@ -9,7 +9,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'react-toastify';
 import axios, { isAxiosError } from 'axios';
 import userState from '@/utils/user-state';
-
+import Cookies from 'js-cookie';
 function signin() {
   const navigate = useNavigate();
 
@@ -32,7 +32,12 @@ function signin() {
           password,
         }
       );
-
+      Cookies.set('accessToken', response.data.accessToken, {
+        expires: new Date(new Date().getTime() + 20 * 1000)
+      });
+      Cookies.set('refreshToken', response.data.refreshToken, {
+        expires: new Date(new Date().getTime() + 20 * 1000)
+      }) 
       userState.setUser(response?.data?.accessToken);
       toast.success(response.data.message);
 

--- a/frontend/src/pages/signup-page.tsx
+++ b/frontend/src/pages/signup-page.tsx
@@ -9,7 +9,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'react-toastify';
 import axios, { isAxiosError } from 'axios';
 import userState from '@/utils/user-state';
-
+import Cookies from 'js-cookie';
 function signin() {
   const navigate = useNavigate();
 
@@ -33,7 +33,12 @@ function signin() {
           password,
         }
       );
-
+      Cookies.set('accessToken', response?.data.accessToken, {
+        expires: new Date(new Date().getTime() + 240 * 1000)
+      });
+      Cookies.set('refreshToken', response?.data.refreshToken, {
+        expires: new Date(new Date().getTime() + 240 * 1000)
+      }) 
       userState.setUser(response?.data?.accessToken);
       toast.success(response.data.message);
 


### PR DESCRIPTION
## Summary
solved the issue #172 
## Description
whenever we are refreshing the page the home page(header-layout) component will re-render if it is re-render the usestate is set to null because it is not persistent when the page is refresh even it is static

my approach-I got the access token and refresh token from the signin response and I set into the cookie section with expiry of 4 mins. Now the token won't lost it will store persistant in the cookie till the expiry 

## Issue(s) Addressed

- Template should be strictly **Closes <172>**
- Example: Closes #172 

## Prerequisites

- [ yes ] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
