### PR TITLE
BUGFIX-#165: Categories Sidebar UI issue

### DIFF
--- a/frontend/src/components/blog-feed.tsx
+++ b/frontend/src/components/blog-feed.tsx
@@ -72,7 +72,7 @@ export default function BlogFeed() {
             <h2 className="mb-2 cursor-text text-xl font-semibold dark:text-dark-primary">
               Categories
             </h2>
-            <div className="flex flex-wrap gap-3 dark:rounded-lg dark:bg-dark-card dark:p-3">
+            <div className="flex flex-wrap gap-3">
               {categories.map((category) => (
                 <button
                   name="category"


### PR DESCRIPTION
BUGFIX#165 : The UI box on the tags in dark theme is removed and the UI now aligns well with the rest and there is no alignment change while changing from light to dark.

## Summary
The issue was related to the UI miss alignment of the tags under category due to the addition of an box in the dark theme. The purpose of this pr is to remove the styling css of tags section in the dark theme to make it aligned with the light themed UI.

## Description
I first identified the location of the styling and then removed the dark theme clause from the inline style of tailwind css to remove the dark box in the UI

## Issues Addressed
1) Earlier n left sidebar inside Categories Container there is a box showing, while change on Theme On Repetitive switch of Theme There can be seen under the "Categories Box", there is a box over "Tags" which was causing a UI Error.
2) This issue was solved by removing the box with bg-dark from the tags section to make the toggle more user friendly as seen in the before and after images below.
Closes #165

## Images
Before 
![image](https://github.com/krishnaacharyaa/wanderlust/assets/68067897/9ca2129d-3a5d-4130-8ac3-0b4e46787d50)

After
![image](https://github.com/krishnaacharyaa/wanderlust/assets/68067897/1930ec1b-b67e-4ff9-a8be-a9648cee40a2)


