### PR TITLE
fix-#110: Latest post card skeleton alignment bug fixed

### DIFF
--- a/frontend/src/components/skeletons/latest-post-card-skeleton.tsx
+++ b/frontend/src/components/skeletons/latest-post-card-skeleton.tsx
@@ -17,9 +17,8 @@ export const LatestPostCardSkeleton = () => {
       </div>
       <div className="mb-2">
         <Skeleton className="h-6 w-11/12 bg-slate-200 dark:bg-slate-700" />
-        <Skeleton className="mt-2 h-4 w-2/3 bg-slate-200 dark:bg-slate-700" />
       </div>
-      <Skeleton className="h-3 w-1/3 bg-slate-200 dark:bg-slate-700" />
+      <Skeleton className="h-3 w-2/3 bg-slate-200 dark:bg-slate-700" />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

The latest postcard skeleton alignment bug was fixed.

## Description

The latest postcard skeleton now features a slightly wider Author and Date row, with the third row removed.

## Images

![Wanderlust](https://github.com/krishnaacharyaa/wanderlust/assets/103471906/f2c97fe9-4969-4309-9fb1-afcf96db9b49)

## Issue(s) Addressed

Closes [#110 ](https://github.com/krishnaacharyaa/wanderlust/issues/110)

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
