### PR TITLE
Fixed - Height of some cards is of  different length

### DIFF
--- a/frontend/src/components/post-card.tsx
+++ b/frontend/src/components/post-card.tsx
@@ -31,7 +31,7 @@ export default function PostCard({ post, testId = 'postcard' }: { post: Post } &
           <h2 className="mb-2 line-clamp-1 text-base font-semibold text-light-title dark:text-dark-title">
             {post.title}
           </h2>
-          <p className="line-clamp-2 text-sm text-light-description dark:text-dark-description">
+          <p className="line-clamp-1 text-sm text-light-description dark:text-dark-description">
             {post.description}
           </p>
           <div className="mt-4 flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary

To fix the height of the different cards is different .

## Description

This is happening because of the description of some cards can be fitted in single line and for some in double line so due to the  cards having a description to be fitted in the same line causes the cards to be of small length as compare to the cards of description comes in two lines 

Approach for solution :-
I change line clamp from 2 to 1 so that if description have even more length will be clamp after a single line .
Cause  :-
Because two lines description is taking one another line and it will increasing the height .

## Images

Before :-
![Screenshot 2024-05-13 223749](https://github.com/krishnaacharyaa/wanderlust/assets/118350936/b6008397-9daa-4d09-86d6-13d5aaf69f1f)

After
![Screenshot 2024-05-13 223944](https://github.com/krishnaacharyaa/wanderlust/assets/118350936/bc0c1303-a36a-4b60-9eab-fc0c0cc5da42)
 

Closes #220 

- [ x ] Have you followed all the [CONTRIBUTING GUIDELINES]
