### PR TITLE
enhancement-#220: Different Cards under all posts are of different height .

### DIFF
--- a/frontend/src/components/post-card.tsx
+++ b/frontend/src/components/post-card.tsx
@@ -44,7 +44,7 @@ export default function PostCard({ post, testId = 'postcard' }: { post: Post } &
           <h2 className="mb-2 line-clamp-1 text-base font-semibold text-light-title dark:text-dark-title">
             {post.title}
           </h2>
-          <p ref={descriptionRef} className={`${incHeight?"leading-10":""} line-clamp-2  text-sm text-light-description dark:text-dark-description1`}>
+          <p ref={descriptionRef} className={`${incHeight?"leading-10":""} line-clamp-2  text-sm text-light-description dark:text-dark-description`}>
             {post.description}
           </p>
           <div className="mt-4 flex flex-wrap gap-2">

--- a/frontend/src/components/post-card.tsx
+++ b/frontend/src/components/post-card.tsx
@@ -4,10 +4,23 @@ import formatPostTime from '@/utils/format-post-time';
 import CategoryPill from '@/components/category-pill';
 import { createSlug } from '@/utils/slug-generator';
 import { TestProps } from '@/types/test-props';
+import { useEffect, useRef, useState } from 'react';
 
 export default function PostCard({ post, testId = 'postcard' }: { post: Post } & TestProps) {
   const navigate = useNavigate();
   const slug = createSlug(post.title);
+  const descriptionRef = useRef(null);
+  const [incHeight,setIncHeight]=useState(false)
+  useEffect(()=>{
+    const descriptionElement = descriptionRef.current;
+    if (descriptionElement) {
+      const scrollHeight = descriptionElement.scrollHeight;
+      const clientHeight = descriptionElement.clientHeight;
+      if (clientHeight === scrollHeight) {
+        setIncHeight(true)
+      } 
+    }
+  },[incHeight])
   return (
     <div
       className={`active:scale-click group w-full sm:w-1/2 lg:w-1/3 xl:w-1/4`}
@@ -31,7 +44,7 @@ export default function PostCard({ post, testId = 'postcard' }: { post: Post } &
           <h2 className="mb-2 line-clamp-1 text-base font-semibold text-light-title dark:text-dark-title">
             {post.title}
           </h2>
-          <p className="line-clamp-2 text-sm text-light-description dark:text-dark-description">
+          <p ref={descriptionRef} className={`${incHeight?"leading-10":""} line-clamp-2  text-sm text-light-description dark:text-dark-description1`}>
             {post.description}
           </p>
           <div className="mt-4 flex flex-wrap gap-2">


### PR DESCRIPTION

## Summary

This PR is for proper height of different cards under All post section .
## Description

Before different cards showing different length but i added javascript to know whether the description of single line or two lines if description is of single lines so changes line-height from 1.25 rem to double 2.5rem .

## Images
Before 
![Screenshot 2024-05-13 223749](https://github.com/krishnaacharyaa/wanderlust/assets/118350936/27001e54-543a-476e-a6f4-7f95be684218)

After 
![Screenshot 2024-05-13 223944](https://github.com/krishnaacharyaa/wanderlust/assets/118350936/69b472cd-40a6-45cb-b3d0-cb6113189f6e)
## Issue(s) Addressed

Closes  #220


## Prerequisites

- [ Yes] Have you followed all the [CONTRIBUTING GUIDELINES]

