### PR TITLE
fix-#258: Now icons are visible in mobile screen instead of both button + icons ( login, logout and creat post) and aligned header too.

### DIFF
--- a/frontend/src/layouts/header-layout.tsx
+++ b/frontend/src/layouts/header-layout.tsx
@@ -53,7 +53,7 @@ function header() {
   return (
     <div className="relative -mt-2 h-[460px] bg-[url('./assets/wanderlustbg.webp')] bg-cover bg-fixed bg-center">
       <div className="absolute inset-0 bg-black opacity-50"></div>
-      <div className="absolute inset-0 flex flex-col px-4 py-8 text-slate-50 sm:px-8 lg:px-16">
+      <div className="absolute inset-0 flex flex-col px-8 py-8 text-slate-50 sm:px-16">
         <div className="flex w-full justify-between">
           <div className="flex cursor-text items-center justify-between text-2xl font-semibold">
             WanderLust

--- a/frontend/src/layouts/header-layout.tsx
+++ b/frontend/src/layouts/header-layout.tsx
@@ -53,22 +53,22 @@ function header() {
   return (
     <div className="relative -mt-2 h-[460px] bg-[url('./assets/wanderlustbg.webp')] bg-cover bg-fixed bg-center">
       <div className="absolute inset-0 bg-black opacity-50"></div>
-      <div className="absolute inset-0 flex flex-col px-4 py-8 text-slate-50 sm:px-16">
+      <div className="absolute inset-0 flex flex-col px-4 py-8 text-slate-50 sm:px-8 lg:px-16">
         <div className="flex w-full justify-between">
           <div className="flex cursor-text items-center justify-between text-2xl font-semibold">
             WanderLust
           </div>
           <div className="flex justify-between items-center">
-            <div className="flex items-center justify-end sm:px-20">
+            <div className="flex items-center justify-end px-4 sm:px-20">
               <ThemeToggle />
             </div>
             <div>
               {loading ? (
                 <Loader />
               ) : token ? (
-                <div className="flex gap-2 ">
+                <div className="flex gap-2">
                   <button
-                    className="active:scale-click rounded border border-slate-50 px-4 py-2 hover:bg-slate-500/25 md:inline-block"
+                    className="active:scale-click rounded border border-slate-50 px-4 py-2 hidden hover:bg-slate-500/25 md:inline-block"
                     onClick={() => {
                       navigate('/add-blog');
                     }}
@@ -76,7 +76,7 @@ function header() {
                     Create post
                   </button>
                   <button
-                    className="active:scale-click rounded border border-slate-50 px-4 py-2 hover:bg-slate-500/25 md:inline-block"
+                    className="active:scale-click rounded border border-slate-50 px-4 py-2 hidden hover:bg-slate-500/25 md:inline-block"
                     onClick={() => {
                       handleLogout();
                     }}
@@ -104,7 +104,7 @@ function header() {
                 <div className="flex">
                   {' '}
                   <button
-                    className="active:scale-click rounded border border-slate-50 px-4 py-2 hover:bg-slate-500/25 md:inline-block"
+                    className="active:scale-click rounded border border-slate-50 px-4 py-2 hidden hover:bg-slate-500/25 md:inline-block"
                     onClick={() => {
                       navigate('/signin');
                     }}


### PR DESCRIPTION
## Summary

This PR aims to display icons in mobile screen + resolves header alignment.

## Description

This PR is basically makes the buttons hidden in mobile screen so that icons can be visible. And gives some styling to make header aligned with overall application.

## Images

Current behavior as expected :-
![Screenshot 2024-05-17 020551](https://github.com/krishnaacharyaa/wanderlust/assets/114509045/337e38f8-eafb-4c76-9209-51546230d0f7)

![Screenshot 2024-05-17 020611](https://github.com/krishnaacharyaa/wanderlust/assets/114509045/1247fdcd-3091-4e6b-b50f-a34544ace95f)

## Issue(s) Addressed

closes #258 

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
