### PR TITLE
feat: Add background-color & border in the card skeleton in the light mode…

### DIFF
--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -1,1 +1,0 @@
-VITE_API_PATH="http://localhost:8080"

--- a/frontend/src/components/featured-post-card.tsx
+++ b/frontend/src/components/featured-post-card.tsx
@@ -13,7 +13,7 @@ export default function FeaturedPostCard({
   const slug = createSlug(post.title);
   return (
     <div
-      className={`active:scale-click group flex h-auto cursor-pointer flex-col gap-2 rounded-lg bg-light dark:bg-dark-card sm:h-48 sm:flex-row`}
+      className={`active:scale-click group flex h-auto cursor-pointer flex-col gap-2 rounded-lg bg-slate-50 border border-slate-200 dark:bg-dark-card sm:h-48 sm:flex-row`}
       onClick={() => navigate(`/details-page/${slug}/${post._id}`, { state: { post } })}
       data-testid={testId}
     >
@@ -21,7 +21,7 @@ export default function FeaturedPostCard({
         <img
           src={post.imageLink}
           alt={post.title}
-          className={`sm:group-hover:scale-hover h-48 w-full rounded-lg object-cover shadow-lg transition-transform ease-in-out sm:h-full`}
+          className={`sm:group-hover:scale-hover h-48 w-full rounded-l-lg object-cover shadow-lg transition-transform ease-in-out sm:h-full`}
         />
       </div>
       <div className="flex h-full w-full flex-col gap-2 p-3 sm:w-2/3">

--- a/frontend/src/components/featured-post-card.tsx
+++ b/frontend/src/components/featured-post-card.tsx
@@ -13,7 +13,7 @@ export default function FeaturedPostCard({
   const slug = createSlug(post.title);
   return (
     <div
-      className={`active:scale-click group flex h-auto cursor-pointer flex-col gap-2 rounded-lg bg-slate-50 border border-slate-200 dark:bg-dark-card sm:h-48 sm:flex-row`}
+      className={`active:scale-click group flex h-auto cursor-pointer flex-col gap-2 rounded-lg bg-slate-50 border border-slate-200 dark:bg-dark-card border-none sm:h-48 sm:flex-row`}
       onClick={() => navigate(`/details-page/${slug}/${post._id}`, { state: { post } })}
       data-testid={testId}
     >


### PR DESCRIPTION
… mode

### Summary
Added background-color, border, & change the rounded image to left rounded (looks more better with different background)

### Description
In the dark mode there is **different background color for the card** that represents the blog post but for the light mode it appears to blend with white background, **changed the background color** to _slate-50_ with _border_ to differentiate it from the white background. After doing that the rounded image wan't looking a good fit so changed to _rounded left_ to make it looks nice.

## Images
**Before:**
![Before](https://github.com/krishnaacharyaa/wanderlust/assets/96254453/27a273a2-525a-47f7-add8-5d8d5ec62575)

**After:**
![After](https://github.com/krishnaacharyaa/wanderlust/assets/96254453/73799295-8362-4f6d-829d-bd91a8744f6e)



## Issue(s) Addressed
wasn't issued

## Prerequisites
Yes (Almost)
- [ ] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
