### PR TITLE
feat-#177: cleared the husky bug

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "format": "prettier --write .",
     "test": "vitest run",
-    "coverage": "vitest run --coverage "
+    "coverage": "vitest run --coverage ",
+    "prepare": "cd .. && npm install"
   },
   "lint-staged": {
     "src/**/*.{js,ts,tsx,jsx}": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "concurrently -n \"FRONTEND,BACKEND\" -c \"bgBlue,bgYellow\" -p \"[{name}]\" \"npm run start-frontend\" \"npm run start-backend\"",
     "install-frontend": "cd frontend && npm i",
     "install-backend": "cd backend && npm i",
-    "installer": "npm i && npm run install-backend && npm run install-frontend"
+    "installer": "npm i && npm run install-backend && npm run install-frontend",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "husky": "^8.0.0"


### PR DESCRIPTION
Summary
whenever we are clone the repo and make some commit the .husky(pre-commit) hook did not work.

Description
The reason is we need to download the husky dependency then only .husky folder get initialized but we did not mention the husky dependency neither frontend package.json nor backend package.json. the husky dependency only present in the the root package.json file. now i have written the prepare script in the frontend package.json file it will automatically install entire node module in the root folder.

Prerequisites
[ yes ] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?