### PR TITLE
fix-#159 : Configured Theme changes to light mode on page refresh in add blogs page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,9 +10,14 @@ import AdminUsers from '@/pages/admin-users';
 import AdminBlogs from '@/pages/admin-blogs';
 import NotFound from '@/pages/not-found';
 import UnprotectedRoute from './components/unprotected-route';
+import { useLayoutEffect } from 'react';
 import RequireAuth from './components/require-auth';
+import useThemeClass from './utils/theme-changer';
 
 function App() {
+  useLayoutEffect(() => {
+    useThemeClass();
+  }, []);
   return (
     <BrowserRouter>
       <ScrollToTop />

--- a/frontend/src/components/theme-toggle-button.tsx
+++ b/frontend/src/components/theme-toggle-button.tsx
@@ -1,18 +1,15 @@
 import { useLayoutEffect, useState } from 'react';
 import Sun from '@/assets/svg/sun.svg';
 import Moon from '@/assets/svg/moon.svg';
+import useThemeClass from '@/utils/theme-changer';
 function ThemeToggle() {
   const [isDarkTheme, setIsDarkTheme] = useState<boolean | null>(null);
   const toggleTheme = () => {
     setIsDarkTheme((prevTheme) => (prevTheme === null ? true : !prevTheme));
   };
   useLayoutEffect(() => {
-    const storedTheme = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
-    setIsDarkTheme(storedTheme === 'dark' || (!storedTheme && prefersDark) || null);
-    if (storedTheme === 'dark' || (!storedTheme && prefersDark)) {
-      document.documentElement.classList.add('dark');
-    }
+    const storedTheme = useThemeClass()
+    setIsDarkTheme(storedTheme === 'dark');
   }, []);
 
   useLayoutEffect(() => {

--- a/frontend/src/pages/not-found.tsx
+++ b/frontend/src/pages/not-found.tsx
@@ -4,7 +4,7 @@ import Particles, { initParticlesEngine } from '@tsparticles/react';
 import { loadFull } from 'tsparticles';
 import ThemeToggle from '@/components/theme-toggle-button';
 
-function ErrorPage() {
+function NotFound() {
   const [isDarkTheme, setIsDarkTheme] = useState<boolean | null>(true);
   const toggleTheme = () => {
     setIsDarkTheme((prevTheme) => (prevTheme === null ? true : !prevTheme));
@@ -132,4 +132,4 @@ function ErrorPage() {
   );
 }
 
-export default ErrorPage;
+export default NotFound;

--- a/frontend/src/utils/theme-changer.ts
+++ b/frontend/src/utils/theme-changer.ts
@@ -1,0 +1,10 @@
+const useThemeClass = () => {
+    const storedTheme = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+    const initialTheme = storedTheme === 'dark' || (!storedTheme && prefersDark);
+    initialTheme && document.documentElement.classList.add('dark');
+    if (initialTheme) return 'dark';
+    else return 'light';
+  };
+
+  export default useThemeClass


### PR DESCRIPTION
## Summary

Fixed the issue of the theme changing to light mode on page refresh in the add blogs page by adding the class "dark" to the document if the theme is set to "dark" in local storage.

## Description

The issue occurred because the class list did not include "dark" while in dark mode, so I added it when the theme is set to "dark" in local storage.

## Issue(s) Addressed
Closes #159 

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?