### PR TITLE
fix-#270: Added the border and the background-color to differentiate white background of the blog post card.

### DIFF
--- a/frontend/src/components/featured-post-card.tsx
+++ b/frontend/src/components/featured-post-card.tsx
@@ -13,7 +13,7 @@ export default function FeaturedPostCard({
   const slug = createSlug(post.title);
   return (
     <div
-      className={`active:scale-click group flex h-auto cursor-pointer flex-col gap-2 rounded-lg bg-light dark:bg-dark-card sm:h-48 sm:flex-row`}
+      className={`active:scale-click group flex h-auto cursor-pointer flex-col gap-2 rounded-lg bg-slate-50 border dark:bg-dark-card dark:border-none sm:h-48 sm:flex-row`}
       onClick={() => navigate(`/details-page/${slug}/${post._id}`, { state: { post } })}
       data-testid={testId}
     >


### PR DESCRIPTION
##Summary
Added background-color & border to the skeleton card of blog post.

##Description
In the dark mode there is different background color for the card that represents the blog post but for the light mode it blends with white background, so changed the background color to slate-50 with border to differentiate it from the white background.
![Screenshot (193)](https://github.com/krishnaacharyaa/wanderlust/assets/96254453/2c49bbf2-1f6b-4144-bf96-251afea23df3)


## Images
**Before:**
![Before](https://github.com/krishnaacharyaa/wanderlust/assets/96254453/eb1116e7-8254-4831-a2ed-7e136419caa7)


**After:**
![Screenshot (192)](https://github.com/krishnaacharyaa/wanderlust/assets/96254453/f8f06048-2cfd-40ea-ba6c-26418ac2a391)


## Issue(s) Addressed
closes #270 

## Prerequisites
- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
