### PR TITLE
fix-#220: Modified Heights of All Post Section's cards

### DIFF
--- a/frontend/src/components/category-pill.tsx
+++ b/frontend/src/components/category-pill.tsx
@@ -20,7 +20,7 @@ export default function CategoryPill({ category, disabled, selected = false }: C
   return (
     <span
       className={twMerge(
-        'cursor-pointer rounded-3xl px-3 py-1 text-xs font-medium text-light-primary/80 dark:text-dark-primary/80 ',
+        'cursor-pointer rounded-3xl px-3 py-1 text-xs font-medium text-light-primary/80 dark:text-dark-primary/80 overflow-hidden whitespace-nowrap truncate',
         disabled ? disabledColor : getSelectedColor(selected)
       )}
     >

--- a/frontend/src/components/post-card.tsx
+++ b/frontend/src/components/post-card.tsx
@@ -34,7 +34,7 @@ export default function PostCard({ post, testId = 'postcard' }: { post: Post } &
           <p className="line-clamp-2 text-sm text-light-description dark:text-dark-description">
             {post.description}
           </p>
-          <div className="mt-4 flex flex-wrap gap-2">
+          <div className="mt-4 flex gap-2">
             {post.categories.map((category, index) => (
               <CategoryPill key={`${category}-${index}`} category={category} />
             ))}


### PR DESCRIPTION
## Summary

Fixed the different height issue of All post section.


## Description

The cards had different heights, causing inconsistency in the design. So added a Text Truncation (...) property on overflow on the Category Pill, so that it will stay in one line and won't grow to the next line to increase the size of the card. 

## Images
![Screenshot 2024-05-21 014245](https://github.com/krishnaacharyaa/wanderlust/assets/107207581/f03a0189-87f2-478a-a4a6-9903dee074de)

## Issue(s) Addressed

Closes #220 

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
