### PR TITLE
fix-#108: Fixed bug by adding responsiveness and inlining the skeleton.

### DIFF
--- a/frontend/src/components/skeletons/post-card-skeleton.tsx
+++ b/frontend/src/components/skeletons/post-card-skeleton.tsx
@@ -6,10 +6,10 @@ export const PostCardSkeleton = () => {
       <div className="mb-4 mr-8 mt-4 rounded-lg bg-light shadow-md dark:bg-dark-card">
         <Skeleton className="h-48 w-full rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="p-4">
-          <Skeleton className="mb-2 h-3 w-full bg-slate-200 dark:bg-slate-700 sm:w-2/3" />
-          <Skeleton className="mb-2 h-6 w-full bg-slate-200 dark:bg-slate-700 sm:w-4/5" />
-          <Skeleton className="h-16 w-full bg-slate-200 dark:bg-slate-700 sm:w-11/12" />
-          <div className="mt-2 flex flex-wrap gap-2">
+          <Skeleton className="mb-2 h-3 w-full pr-4 bg-slate-200 dark:bg-slate-700 sm:w-full" />
+          <Skeleton className="mb-2 h-6 w-full pr-4 bg-slate-200 dark:bg-slate-700 sm:w-full" />
+          <Skeleton className="h-16 w-full pr-4 bg-slate-200 dark:bg-slate-700 sm:w-full" />
+          <div className="mt-2 flex flex-wrap gap-1 sm:gap-2">
             <Skeleton
               className={`h-6 w-full rounded-full sm:w-16 ${'sm:mr-8 sm:mt-4'} bg-slate-200 dark:bg-slate-700 sm:mb-4`}
             />


### PR DESCRIPTION
## Summary

Inlining posts with full-width and making it responsive.

## Description

This PR is according to changes made in post-card-skeleton to make padding properly and making changes to handle properly in all the screens, added pr-4 for padding, gap-1, gap-2 for spacing along with responsiveness with w-full.

## Images

![image](https://github.com/krishnaacharyaa/wanderlust/assets/129886894/050d76b9-6d95-4244-aba9-02dad230ce5e)

![image](https://github.com/krishnaacharyaa/wanderlust/assets/129886894/891cbc87-8e88-42be-b902-8e4797433a06)

![image](https://github.com/krishnaacharyaa/wanderlust/assets/129886894/d27ea5f1-26e5-4dbf-8c8a-631633e6a8fa)

## Issue(s) Addressed

Closes #108

## Prerequisites

- [ ] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
