### PR TITLE
fix-#220: Fixed Heights of All Post Section's cards

### DIFF
--- a/frontend/src/components/category-pill.tsx
+++ b/frontend/src/components/category-pill.tsx
@@ -20,7 +20,7 @@ export default function CategoryPill({ category, disabled, selected = false }: C
   return (
     <span
       className={twMerge(
-        'cursor-pointer rounded-3xl px-3 py-1 text-xs font-medium text-light-primary/80 dark:text-dark-primary/80 ',
+        'cursor-pointer rounded-3xl px-3 py-1 text-xs font-medium text-light-primary/80 dark:text-dark-primary/80 overflow-hidden whitespace-nowrap truncate',
         disabled ? disabledColor : getSelectedColor(selected)
       )}
     >

--- a/frontend/src/components/post-card.tsx
+++ b/frontend/src/components/post-card.tsx
@@ -34,8 +34,8 @@ export default function PostCard({ post, testId = 'postcard' }: { post: Post } &
           <p className="line-clamp-2 text-sm text-light-description dark:text-dark-description">
             {post.description}
           </p>
-          <div className="mt-4 flex flex-wrap gap-2">
-            {post.categories.map((category, index) => (
+          <div className="mt-4 flex gap-2">
+            {post.categories.slice(0, 3).map((category, index) => (
               <CategoryPill key={`${category}-${index}`} category={category} />
             ))}
           </div>


### PR DESCRIPTION
## Summary

Fixed the different height issues of All post sections.

## Description

The cards had different heights, causing inconsistency in the design. So added a Text Truncation (...) property on overflow on the Category Pill and sliced the category array into just  first 3 pills, so that it will stay in one line and won't grow to the next line to increase the size of the card.

## Images

![Screenshot 2024-05-25 002517](https://github.com/krishnaacharyaa/wanderlust/assets/107207581/4907d980-ded3-4a95-8196-546d74c80258)


## Issue(s) Addressed

 Closes #220 

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
