### PR TITLE
fix-#358: Add the limit to the json payload 

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -16,7 +16,7 @@ app.use(cors({
     credentials: true
 }));
 app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
+app.use(express.urlencoded());
 app.use(cookieParser());
 app.use(compression());
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -15,7 +15,7 @@ app.use(cors({
     origin: FRONTEND_URL,
     credentials: true
 }));
-app.use(express.json());
+app.use(express.json( { limit: '50kb' }));
 app.use(express.urlencoded());
 app.use(cookieParser());
 app.use(compression());


### PR DESCRIPTION
## Summary

Added the limit to the json payload that is sent.

## Description

The actual payload that user can submit to your app /api should be restricted to avoid unnecessary behaviour/ overload of the data. Therefore there should be a limit to the body payload.
app.use(express.json( { limit: '50kb' }));  //we can change set the max limit according to the usage.

## Issue(s) Addressed

- Closes #358 

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
