### PR TITLE
fix-#387: Feature, logo added beside wanderlust heading in navbar

### DIFF
--- a/frontend/src/layouts/header-layout.tsx
+++ b/frontend/src/layouts/header-layout.tsx
@@ -54,8 +54,13 @@ function header() {
       <div className="absolute inset-0 bg-black opacity-50"></div>
       <div className="absolute inset-0 flex flex-col px-8 py-8 text-slate-50 sm:px-16">
         <div className="flex w-full justify-between">
-          <div className="flex cursor-text items-center justify-between text-2xl font-semibold">
-            WanderLust
+          <div className="flex cursor-text items-center justify-between gap-3 text-2xl font-semibold">
+            <a href="/">
+              <img className="flex h-12 w-12" src="./src/assets/svg/app-icon.svg"></img>
+            </a>
+            <a href="/" className="text-decoration-none text-slate-50">
+              WanderLust
+            </a>
           </div>
           <div className="flex items-center justify-between">
             <div className="flex items-center justify-end px-4 sm:px-20">


### PR DESCRIPTION
## Summary
Added logo beside wanderlust title along with anchor tag

## Description
Thier was no logo with the title in navbar. I have taken logo which I saw as favicon from index.html which is shown as website tab bar icon. Even as additional added anchor tag to logo to redirect directly to home page.

## Images
![Logo added](https://github.com/krishnaacharyaa/wanderlust/assets/105008414/78671c6a-c5f3-4ada-8417-9503150b033a)


## Issue(s) Addressed
Closes #387 

## Prerequisites

- [X] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
