### PR TITLE
fix-#392: added related blogs section in detailed blog page

### DIFF
--- a/backend/controllers/posts-controller.js
+++ b/backend/controllers/posts-controller.js
@@ -157,3 +157,21 @@ export const deletePostByIdHandler = async (req, res) => {
     res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ message: err.message });
   }
 };
+
+export const getAllCategoryPosts = async (req, res) => {
+  const { categories } = req.query;
+  if (!categories) {
+    return res
+      .status(HTTP_STATUS.NOT_FOUND)
+      .json({ message: RESPONSE_MESSAGES.POSTS.CATEGORIES_NOTFOUND });
+  }
+  const categoryArray = categories.split(',');
+  try {
+    const filteredCategoryPosts = await Post.find({
+      categories: { $in: categoryArray },
+    });
+    res.status(HTTP_STATUS.OK).json(filteredCategoryPosts);
+  } catch (err) {
+    res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({ message: err.message });
+  }
+};

--- a/backend/controllers/posts-controller.js
+++ b/backend/controllers/posts-controller.js
@@ -158,17 +158,16 @@ export const deletePostByIdHandler = async (req, res) => {
   }
 };
 
-export const getAllCategoryPosts = async (req, res) => {
+export const getRelatedPostsByCategories = async (req, res) => {
   const { categories } = req.query;
   if (!categories) {
     return res
       .status(HTTP_STATUS.NOT_FOUND)
       .json({ message: RESPONSE_MESSAGES.POSTS.CATEGORIES_NOTFOUND });
   }
-  const categoryArray = categories.split(',');
   try {
     const filteredCategoryPosts = await Post.find({
-      categories: { $in: categoryArray },
+      categories: { $in: categories },
     });
     res.status(HTTP_STATUS.OK).json(filteredCategoryPosts);
   } catch (err) {

--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -2,12 +2,12 @@ import { Router } from 'express';
 import {
   createPostHandler,
   deletePostByIdHandler,
-  getAllCategoryPosts,
   getAllPostsHandler,
   getFeaturedPostsHandler,
   getLatestPostsHandler,
   getPostByCategoryHandler,
   getPostByIdHandler,
+  getRelatedPostsByCategories,
   updatePostHandler,
 } from '../controllers/posts-controller.js';
 import { REDIS_KEYS } from '../utils/constants.js';
@@ -26,7 +26,7 @@ router.get('/', cacheHandler(REDIS_KEYS.ALL_POSTS), getAllPostsHandler);
 router.get('/featured', cacheHandler(REDIS_KEYS.FEATURED_POSTS), getFeaturedPostsHandler);
 
 // Route to get related category posts
-router.get('/AllCategories', getAllCategoryPosts);
+router.get('/related-posts-by-category', getRelatedPostsByCategories);
 
 // Route to get posts by category
 router.get('/categories/:category', getPostByCategoryHandler);

--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import {
   createPostHandler,
   deletePostByIdHandler,
+  getAllCategoryPosts,
   getAllPostsHandler,
   getFeaturedPostsHandler,
   getLatestPostsHandler,
@@ -23,6 +24,9 @@ router.get('/', cacheHandler(REDIS_KEYS.ALL_POSTS), getAllPostsHandler);
 
 // Route to get featured posts
 router.get('/featured', cacheHandler(REDIS_KEYS.FEATURED_POSTS), getFeaturedPostsHandler);
+
+// Route to get related category posts
+router.get('/AllCategories', getAllCategoryPosts);
 
 // Route to get posts by category
 router.get('/categories/:category', getPostByCategoryHandler);

--- a/frontend/src/assets/svg/arrow-right-black.svg
+++ b/frontend/src/assets/svg/arrow-right-black.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="#000000" viewBox="0 0 24 24" width="24px" height="24px">
+  <path d="M0 0h24v24H0z" fill="none"/>
+  <path d="M10 17l5-5-5-5v10z"/>
+</svg>

--- a/frontend/src/assets/svg/arrow-right-white.svg
+++ b/frontend/src/assets/svg/arrow-right-white.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="#9CA3AF" viewBox="0 0 24 24" width="24px" height="24px">
+  <path d="M0 0h24v24H0z" fill="none"/>
+  <path d="M10 17l5-5-5-5v10z"/>
+</svg>

--- a/frontend/src/assets/svg/arrow-right.svg
+++ b/frontend/src/assets/svg/arrow-right.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="#FFFFFF" viewBox="0 0 24 24" width="24px" height="24px">
-  <path d="M0 0h24v24H0z" fill="none"/>
-  <path d="M10 17l5-5-5-5v10z"/>
-</svg>

--- a/frontend/src/assets/svg/arrow-right.svg
+++ b/frontend/src/assets/svg/arrow-right.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="#FFFFFF" viewBox="0 0 24 24" width="24px" height="24px">
+  <path d="M0 0h24v24H0z" fill="none"/>
+  <path d="M10 17l5-5-5-5v10z"/>
+</svg>

--- a/frontend/src/components/PostMobileViewCardSkeleton.tsx
+++ b/frontend/src/components/PostMobileViewCardSkeleton.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from './ui/skeleton';
+
+export function PostMobileViewCardSkeleton() {
+  return (
+    <div
+      className="flex h-fit rounded-lg border bg-slate-50 dark:border-none dark:bg-dark-card"
+      data-testid={'postMobileViewCardSkeleton'}
+    >
+      <div className="flex h-fit w-full gap-2 p-3">
+        <Skeleton className="w-1/3 overflow-hidden  rounded-lg bg-slate-200 dark:bg-slate-700" />
+        <div className="flex h-full w-2/3 flex-col gap-2 ">
+          <Skeleton className="mb-2 h-3 w-full bg-slate-200 pr-2 dark:bg-slate-700" />
+          <div className="mt-1 flex flex-wrap gap-1 sm:mt-2 sm:gap-1.5">
+            <Skeleton className={`h-6 w-16 rounded-full bg-slate-200 dark:bg-slate-700`} />
+            <Skeleton className={`h-6 w-16 rounded-full bg-slate-200 dark:bg-slate-700`} />
+          </div>
+          <Skeleton className="mb-2 h-6 w-full bg-slate-200 pr-2 dark:bg-slate-700 sm:mb-4" />
+          <Skeleton className="mb-2 h-3 w-full bg-slate-200 pr-2 dark:bg-slate-700" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PostMobileViewComponent.tsx
+++ b/frontend/src/components/PostMobileViewComponent.tsx
@@ -1,0 +1,52 @@
+import Post from '@/types/post-type';
+import CategoryPill from './category-pill';
+import formatPostTime from '@/utils/format-post-time';
+import { useNavigate } from 'react-router-dom';
+import { createSlug } from '@/utils/slug-generator';
+
+export default function PostMobileViewComponent({
+  post,
+  testId = 'postMobileViewCard',
+}: {
+  post: Post;
+  testId?: string;
+}) {
+  const navigate = useNavigate();
+  const slug = createSlug(post.title);
+  return (
+    <div
+      className="active:scale-click group flex h-fit cursor-pointer rounded-lg border bg-slate-50 dark:border-none dark:bg-dark-card"
+      onClick={() => {
+        navigate(`/details-page/${slug}/${post._id}`, { state: { post } });
+      }}
+      data-testid={testId}
+    >
+      <div className="flex h-fit w-full gap-2 p-3">
+        <div className="w-1/3 overflow-hidden">
+          <img
+            src={post.imageLink}
+            className="group-hover:scale-hover h-32 w-32 rounded-lg object-cover shadow-lg transition-transform ease-in-out"
+          />
+        </div>
+        <div className="flex h-full w-2/3 flex-col gap-2 ">
+          <div className="line-clamp-1 text-base font-semibold text-light-title dark:text-dark-title">
+            {post.title}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {post.categories.map((category, index) => (
+              <CategoryPill key={`${category}-${index}`} category={category} />
+            ))}
+          </div>
+          <div className="line-clamp-2 ">
+            <p className="overflow-ellipsis text-light-description dark:text-dark-description">
+              {post.description}
+            </p>
+          </div>
+          <div className="text-xs text-light-info dark:text-dark-info">
+            {post.authorName} • {formatPostTime(post.timeOfPost)}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/skeletons/related-post-card-skeleton.tsx
+++ b/frontend/src/components/skeletons/related-post-card-skeleton.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from '../ui/skeleton';
+
+export function PostMobileViewCardSkeleton() {
+  return (
+    <div
+      className="flex h-fit rounded-lg border bg-slate-50 dark:border-none dark:bg-dark-card"
+      data-testid={'postMobileViewCardSkeleton'}
+    >
+      <div className="flex h-fit w-full gap-2 p-3">
+        <Skeleton className="w-1/3 overflow-hidden  rounded-lg bg-slate-200 dark:bg-slate-700" />
+        <div className="flex h-full w-2/3 flex-col gap-2 ">
+          <Skeleton className="mb-2 h-3 w-full bg-slate-200 pr-2 dark:bg-slate-700" />
+          <div className="mt-1 flex flex-wrap gap-1 sm:mt-2 sm:gap-1.5">
+            <Skeleton className={`h-6 w-16 rounded-full bg-slate-200 dark:bg-slate-700`} />
+            <Skeleton className={`h-6 w-16 rounded-full bg-slate-200 dark:bg-slate-700`} />
+          </div>
+          <Skeleton className="mb-2 h-6 w-full bg-slate-200 pr-2 dark:bg-slate-700 sm:mb-4" />
+          <Skeleton className="mb-2 h-3 w-full bg-slate-200 pr-2 dark:bg-slate-700" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/details-page.tsx
+++ b/frontend/src/pages/details-page.tsx
@@ -1,9 +1,14 @@
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import navigateBackWhiteIcon from '@/assets/svg/navigate-back-white.svg';
 import formatPostTime from '@/utils/format-post-time';
 import CategoryPill from '@/components/category-pill';
 import { useEffect, useState } from 'react';
 import axios from 'axios';
+import Post from '@/types/post-type';
+import axiosInstance from '@/helpers/axios-instance';
+import { ArrowBigRight } from 'lucide-react';
+import { PostCardSkeleton } from '@/components/skeletons/post-card-skeleton';
+import PostCard from '@/components/post-card';
 
 export default function DetailsPage() {
   const { state } = useLocation();
@@ -12,6 +17,8 @@ export default function DetailsPage() {
   const [loading, setIsLoading] = useState(initialVal);
   const { postId } = useParams();
   const navigate = useNavigate();
+  const [categoryPosts, setcategoryPosts] = useState<Post[]>([]);
+  const [postLoading, setpostLoading] = useState(false);
 
   useEffect(() => {
     const getPostById = async () => {
@@ -29,6 +36,24 @@ export default function DetailsPage() {
       getPostById();
     }
   }, [post]);
+
+  const category = post.categories[0];
+  useEffect(() => {
+    const fetchCategoryPost = async () => {
+      try {
+        setpostLoading(true);
+        const res = await axiosInstance.get(`/api/posts/categories/${category}`);
+        const filterdPosts = res.data.filter((item: Post) => item._id !== post._id);
+        const posts = filterdPosts.slice(0, 4);
+        setcategoryPosts(posts);
+        setpostLoading(false);
+      } catch (err) {
+        console.log(err);
+        setpostLoading(false);
+      }
+    };
+    fetchCategoryPost();
+  }, [category]);
 
   if (!loading)
     return (
@@ -64,6 +89,24 @@ export default function DetailsPage() {
             <p className="leading-7 text-light-secondary dark:text-dark-secondary sm:text-lg">
               {post.description}
             </p>
+          </div>
+        </div>
+        <div className="container mx-auto flex flex-col px-4 py-6 text-white">
+          <div className="flex justify-between text-2xl font-semibold">
+            <div>Related Blogs</div>
+            <div className="mr-8 flex cursor-pointer items-center gap-1 text-gray-400 hover:underline">
+              <Link to="/">
+                <div className="text-sm">see more blogs</div>
+              </Link>
+              <ArrowBigRight className="h-6 w-6" />
+            </div>
+          </div>
+          <div className="flex flex-wrap">
+            {categoryPosts.length === 0 && postLoading
+              ? Array(4)
+                  .fill(0)
+                  .map((_, index) => <PostCardSkeleton key={index} />)
+              : categoryPosts.map((post) => <PostCard key={post._id} post={post} />)}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/details-page.tsx
+++ b/frontend/src/pages/details-page.tsx
@@ -101,9 +101,9 @@ export default function DetailsPage() {
           </div>
         </div>
         <div className="container mx-auto flex flex-col space-y-2 px-4 py-6 dark:text-white">
-          <div className="flex flex-col text-2xl font-semibold sm:flex-col md:ml-4 md:flex-row  md:justify-between ">
+          <div className="flex justify-between text-2xl font-semibold ">
             <div>Related Blogs</div>
-            <div className="mr-10 flex cursor-pointer items-center text-sm text-gray-400 hover:underline">
+            <div className="flex cursor-pointer items-center text-sm text-gray-400 hover:underline sm:mr-10">
               <Link to="/">
                 <div>see more blogs</div>
               </Link>

--- a/frontend/src/pages/details-page.tsx
+++ b/frontend/src/pages/details-page.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import navigateBackWhiteIcon from '@/assets/svg/navigate-back-white.svg';
-import arrowRightIcon from '@/assets/svg/arrow-right.svg';
+import arrowRightWhiteIcon from '@/assets/svg/arrow-right-white.svg';
+import arrowRightBlackIcon from '@/assets/svg/arrow-right-black.svg';
 import formatPostTime from '@/utils/format-post-time';
 import CategoryPill from '@/components/category-pill';
 import { useEffect, useState } from 'react';
@@ -10,6 +11,7 @@ import axiosInstance from '@/helpers/axios-instance';
 import { PostCardSkeleton } from '@/components/skeletons/post-card-skeleton';
 import PostCard from '@/components/post-card';
 import PostMobileViewComponent from '@/components/PostMobileViewComponent';
+import { PostMobileViewCardSkeleton } from '@/components/PostMobileViewCardSkeleton';
 
 export default function DetailsPage() {
   const { state } = useLocation();
@@ -20,6 +22,12 @@ export default function DetailsPage() {
   const navigate = useNavigate();
   const [relatedCategoryPosts, setRelatedCategoryPosts] = useState<Post[]>([]);
   const [relatedPostsLoading, setRelatedPostsLoading] = useState<boolean>(false);
+  const [isDarkMode, setIsDarkMode] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const theme = localStorage.getItem('theme');
+    setIsDarkMode(theme === 'dark');
+  }, []);
 
   useEffect(() => {
     const getPostById = async () => {
@@ -92,25 +100,25 @@ export default function DetailsPage() {
             </p>
           </div>
         </div>
-        <div className="container mx-auto flex flex-col px-4 py-6 text-white">
-          <div className="ml-4 flex justify-between text-2xl font-semibold  ">
+        <div className="container mx-auto flex flex-col space-y-2 px-4 py-6 dark:text-white">
+          <div className="flex flex-col text-2xl font-semibold sm:flex-col md:ml-4 md:flex-row  md:justify-between ">
             <div>Related Blogs</div>
-            <div className="mr-10 flex  cursor-pointer items-center gap-1 text-gray-400 hover:underline">
+            <div className="mr-10 flex cursor-pointer items-center text-sm text-gray-400 hover:underline">
               <Link to="/">
-                <div className="text-sm">see more blogs</div>
+                <div>see more blogs</div>
               </Link>
               <img
                 alt="arrow-right"
-                src={arrowRightIcon}
-                className="active:scale-click h-10 w-10 "
+                src={isDarkMode ? arrowRightWhiteIcon : arrowRightBlackIcon}
+                className="active:scale-click h-8 w-8"
               />
             </div>
           </div>
           <div className="block space-y-4 sm:hidden">
             {relatedPostsLoading
-              ? Array(4)
+              ? Array(3)
                   .fill(0)
-                  .map((_, index) => <PostCardSkeleton key={index} />)
+                  .map((_, index) => <PostMobileViewCardSkeleton key={index} />)
               : relatedCategoryPosts
                   .slice(0, 3)
                   .map((post) => <PostMobileViewComponent key={post._id} post={post} />)}


### PR DESCRIPTION
## Summary

added  related blogs section in detailed blog page

## Description

whenever user visited individual blog page..they can see related posts based on the categories in the blog page

## Images
desktop view
![Screenshot (200)](https://github.com/krishnaacharyaa/wanderlust/assets/127492265/b8232dc8-0838-4168-b57b-c999c717d834)

mobile view
![Screenshot (201)](https://github.com/krishnaacharyaa/wanderlust/assets/127492265/cb08e2d9-fd62-414b-a470-fb3f30b6c071)


## Issue(s) Addressed

Closes #392 

## Prerequisites

- [ yes] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
