### PR TITLE
fix-#427: Toggle show password feature added in sign-up page

### DIFF
--- a/frontend/src/pages/signin-page.tsx
+++ b/frontend/src/pages/signin-page.tsx
@@ -17,7 +17,7 @@ import EyeOffIcon from '@/assets/svg/eye-off.svg';
 
 function signin() {
   const navigate = useNavigate();
-  const [passwordVisible, setPasswordVisible] = useState(false);
+  const [passwordVisible, setPasswordVisible] = useState<boolean>(false);
   const {
     register,
     handleSubmit,

--- a/frontend/src/pages/signup-page.tsx
+++ b/frontend/src/pages/signup-page.tsx
@@ -11,7 +11,14 @@ import { AxiosError, isAxiosError } from 'axios';
 import axiosInstance from '@/helpers/axios-instance';
 import userState from '@/utils/user-state';
 import ThemeToggle from '@/components/theme-toggle-button';
+import { useState } from 'react';
+import EyeIcon from '@/assets/svg/eye.svg';
+import EyeOffIcon from '@/assets/svg/eye-off.svg';
+
 function signup() {
+  const [passwordVisible, setPasswordVisible] = useState<boolean>(false);
+  const [confirmPasswordVisible, setconfirmPasswordVisible] = useState<boolean>(false);
+
   const navigate = useNavigate();
   const {
     register,
@@ -106,24 +113,54 @@ function signup() {
               <p className="p-3 text-xs text-red-500">{`${errors.email.message}`}</p>
             )}
           </div>
-          <div className="mb-2">
-            <input
-              {...register('password')}
-              type="password"
-              placeholder="Password"
-              className="w-full rounded-lg bg-zinc-100 p-3 font-normal placeholder:text-sm dark:bg-dark-field dark:text-dark-textInField"
-            />
+
+          {/** Password Section */}
+          <div className="mb-2 flex flex-col">
+            <div className="relative">
+              <input
+                {...register('password')}
+                type={passwordVisible ? 'text' : 'password'}
+                placeholder="Password"
+                className="w-full rounded-lg bg-zinc-100 p-3 font-normal placeholder:text-sm dark:bg-dark-field dark:text-dark-textInField"
+              />
+              <button
+                type="button"
+                onClick={() => setPasswordVisible(!passwordVisible)}
+                className="absolute inset-y-0 right-0 flex items-center pr-3 text-sm leading-5"
+              >
+                <img
+                  src={passwordVisible ? EyeIcon : EyeOffIcon}
+                  alt="Toggle-visibility"
+                  className="h-5 w-5"
+                />
+              </button>
+            </div>
             {errors.password && (
               <p className="p-3 text-xs text-red-500">{`${errors.password.message}`}</p>
             )}
           </div>
-          <div className="mb-4">
-            <input
-              {...register('confirmPassword')}
-              type="password"
-              placeholder="Confirm Password"
-              className="w-full rounded-lg bg-zinc-100 p-3 font-normal placeholder:text-sm dark:bg-dark-field dark:text-dark-textInField"
-            />
+          {/** Confirm Password Section */}
+          <div className="mb-4 flex flex-col">
+            <div className="relative">
+              <input
+                {...register('confirmPassword')}
+                type={confirmPasswordVisible ? 'text' : 'password'}
+                placeholder="Confirm Password"
+                className="w-full rounded-lg bg-zinc-100 p-3 font-normal placeholder:text-sm dark:bg-dark-field dark:text-dark-textInField"
+              />
+
+              <button
+                type="button"
+                onClick={() => setconfirmPasswordVisible(!confirmPasswordVisible)}
+                className="absolute inset-y-0 right-0 flex items-center pr-3 text-sm leading-5"
+              >
+                <img
+                  src={confirmPasswordVisible ? EyeIcon : EyeOffIcon}
+                  alt="Toggle-visibility"
+                  className="h-5 w-5"
+                />
+              </button>
+            </div>
             {errors.confirmPassword && (
               <p className="p-3 text-xs text-red-500">{`${errors.confirmPassword.message}`}</p>
             )}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"compression": "^1.7.4",
 		"concurrently": "^8.2.2"
 	},
 	"scripts": {


### PR DESCRIPTION
## Summary

 This PR adds the functionality to toggle the visibility of the password input field in the sign-up page using a show/hide eye icon.

## Description

Previously, the sign-up page did not have an option to show or hide the password, which could lead to user frustration when entering long or complex passwords. This PR introduces an eye icon next to the password input field, allowing users to toggle the visibility of their password. This enhances the user experience by providing a convenient way to review the entered password before submission.

## Technical Details:
 - Added a state variable to manage the visibility of the password.
 - Included an eye icon button that toggles the password visibility.
 - Updated the password input field to change its type between 'password' and 'text' based on the visibility state.

## Images

### Before
![Screenshot 2024-06-27 193344](https://github.com/krishnaacharyaa/wanderlust/assets/88975566/d3851fc7-199e-47f1-8494-63469ae4809d)

### After
![Screenshot 2024-06-27 193418](https://github.com/krishnaacharyaa/wanderlust/assets/88975566/d15af8f9-5778-4dd1-b9aa-c26f471509df)

## Issue(s) Addressed



Closes #427  

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?
