### PR TITLE
fix-#275: Correct the icon color in dark mode

### DIFF
--- a/frontend/src/components/blog-feed.tsx
+++ b/frontend/src/components/blog-feed.tsx
@@ -14,7 +14,7 @@ export default function BlogFeed() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    let categoryEndpoint =
+    const categoryEndpoint =
       selectedCategory === 'featured'
         ? '/api/posts/featured'
         : `/api/posts/categories/${selectedCategory}`;

--- a/frontend/src/components/latest-post-card.tsx
+++ b/frontend/src/components/latest-post-card.tsx
@@ -24,7 +24,7 @@ export default function LatestPostCard({
             <CategoryPill key={`${category}-${index}`} category={category} />
           ))}
         </div>
-        <img src={linkIcon} alt={post.title} className="h-3 w-3" />
+        <img src={linkIcon} alt={post.title} className="h-4 w-4 dark:invert" />
       </div>
       <div className="mb-2 line-clamp-1 font-semibold text-light-title dark:text-dark-title">
         {post.title}


### PR DESCRIPTION
## Summary

This PR aims to correct the icon color in dark mode to ensure consistency with the theme.

## Description

The current implementation of the icon color in dark mode does not match the overall theme, resulting in a less cohesive user interface. This PR addresses this issue by inverting the icon color in dark mode to ensure it aligns with the theme's color scheme.

## Image 

![Screenshot 2024-07-03 133952](https://github.com/krishnaacharyaa/wanderlust/assets/113468850/8513e02f-bdc1-417b-a17c-28e295717435)


![Screenshot 2024-07-03 134005](https://github.com/krishnaacharyaa/wanderlust/assets/113468850/846a09c2-8abc-44bf-a705-de8ee9de514f)

## Issue(s) Addressed

Closes #275 Correct the icon color in dark mode

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?

