### PR TITLE
fix: typo note_modules in .eslintrc.json

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -10,7 +10,7 @@
     "jest": true,
     "es2021": true
   },
-  "ignorePatterns": ["note_modules/"],
+  "ignorePatterns": ["node_modules/"],
 
   "plugins": ["babel", "jest", "prettier"],
   "rules": {


### PR DESCRIPTION
## Summary

fixed a typo in .eslintrc.json file

## Description

There was a minor typo in .eslintrc.json file at line 13 ("ignorePatterns"), It was written as "note_modules" but it should be "node_modules".

