### PR TITLE
fix-#191: broken google auth

### DIFF
--- a/backend/middlewares/auth-middleware.ts
+++ b/backend/middlewares/auth-middleware.ts
@@ -9,7 +9,7 @@ import { Request, Response, NextFunction } from 'express';
 import { ObjectId } from 'mongoose';
 
 interface JwtPayload {
-  _id: ObjectId;
+  id: ObjectId;
 }
 
 export const authMiddleware = async (req: Request, res: Response, next: NextFunction) => {
@@ -24,8 +24,8 @@ export const authMiddleware = async (req: Request, res: Response, next: NextFunc
   }
 
   try {
-    const { _id } = jwt.verify(token, JWT_SECRET as string) as JwtPayload;
-    req.user = await User.findById(_id);
+    const { id } = jwt.verify(token, JWT_SECRET as string) as JwtPayload;
+    req.user = await User.findById(id);
     next();
   } catch (error: any) {
     console.log('Token verification error:', error);


### PR DESCRIPTION
## Summary

Updated token generation to use id instead of _id for consistency in JWT payload.

## Description

This PR fixes google authentication issue where req.user was null due to a mismatch between the JWT payload key (`id`) and the expected key (`_id`) in authMiddleware.

## Images

NA

## Issue(s) Addressed
Closes #191

## Prerequisites

- [x] Have you followed all the [CONTRIBUTING GUIDELINES](https://github.com/krishnaacharyaa/wanderlust/blob/main/.github/CONTRIBUTING.md#guidelines-for-contributions)?